### PR TITLE
feat: brownfield onboarding — resumable deep architecture scan for both tools

### DIFF
--- a/.claude/agents/sdd-scout.md
+++ b/.claude/agents/sdd-scout.md
@@ -1,0 +1,16 @@
+---
+name: sdd-scout
+description: Architecture scout used only by /sdd-architecture-scan. Analyzes one worklist unit and writes its report to .sdd-scan/reports/. Not for general tasks.
+tools: Read, Grep, Glob, Write
+---
+
+You are the architecture scout for this repository's `/sdd-architecture-scan`
+workflow. You analyze exactly one worklist unit per invocation; the delegation
+message carries the unit, the report path, the schema and `DocLanguage` — follow it
+precisely. Write only inside `.sdd-scan/reports/`. If your unit is too large or
+incoherent for one honest report, return a structural note plus proposed child units
+instead of a shallow report. Return at most five summary lines.
+
+<!-- This file exists twice on purpose (Claude dialect in .claude/agents/sdd-scout.md,
+     VS Code dialect in .github/agents/sdd-scout.agent.md): the frontmatter languages
+     differ, the body is the shared single source. Change both together. -->

--- a/.claude/agents/sdd-scout.md
+++ b/.claude/agents/sdd-scout.md
@@ -7,7 +7,9 @@ tools: Read, Grep, Glob, Write
 You are the architecture scout for this repository's `/sdd-architecture-scan`
 workflow. You analyze exactly one worklist unit per invocation; the delegation
 message carries the unit, the report path, the schema and `DocLanguage` — follow it
-precisely. Write only inside `.sdd-scan/reports/`. If your unit is too large or
+precisely. Analyze by reading and searching only — run no commands and build nothing:
+the scan must stay reproducible and side-effect-free, and command verification is
+Phase C's gated job. Write only inside `.sdd-scan/reports/`. If your unit is too large or
 incoherent for one honest report, return a structural note plus proposed child units
 instead of a shallow report. Return at most five summary lines.
 

--- a/.claude/commands/sdd-architecture-scan.md
+++ b/.claude/commands/sdd-architecture-scan.md
@@ -1,0 +1,102 @@
+---
+description: Deep architecture scan — recursively analyze an existing codebase into the fingerprint. Resumable; safe to re-run anytime.
+argument-hint: "[focus path] (optional)"
+disable-model-invocation: true
+---
+
+<!-- Single source for the /sdd-architecture-scan workflow. Claude Code runs this file
+     directly; GitHub Copilot reaches it through the thin loader in
+     .github/prompts/sdd-architecture-scan.prompt.md. Deliberately no shell injection
+     and no argument-variable substitution: Copilot supports neither. -->
+
+# /sdd-architecture-scan — Deep Architecture Scan
+
+The user may name a focus path after the command; then every phase below applies to
+that subtree only, and the final merge touches only its entries.
+
+## Where am I? (state router — the files decide, not the conversation)
+
+- No `.sdd-scan/_worklist.md` → run **Phase A**, then stop at the worklist gate.
+- Worklist exists with pending units → run **Phase B** on pending units only.
+- All units done, or the user says "distill what we have" → run **Phase C**.
+
+## Phase A — Inventory (git only, no other tooling assumed)
+
+Run and use the results of: `git ls-files` (tree shape, file counts per top-level
+folder); `git ls-files '*.sln' '*.csproj' '**/package.json' '**/pom.xml' '**/go.mod'
+'**/Cargo.toml' '**/pyproject.toml'` (manifests → stack and project graph); per
+candidate source folder `git rev-list --count --since="6 months ago" HEAD -- <folder>`
+(change frequency → priority); read CI configs and test scripts found via `git
+ls-files`. Write `.sdd-scan/_inventory.md` — facts only, no interpretation. Then
+propose analysis units (modules, bounded contexts, projects) with priorities as
+`.sdd-scan/_worklist.md`: a table with columns #, Unit, Path, Parent, Depth, Priority,
+Status (pending | split | done | synthesized), Report.
+
+## Worklist gate (the only gate this command adds)
+
+Present the proposed units and priorities. Unit boundaries need human interpretation:
+say what you guessed, ask what to merge, split or defer, apply the answer, mark the
+worklist confirmed. Never proceed on an unconfirmed worklist.
+
+## Phase B — Scouts (map)
+
+If your environment can delegate work to an isolated agent with its own context
+window — both supported tools can, via the repository's `sdd-scout` agent definition —
+dispatch one scout per pending unit, at most three in parallel. If it cannot, do the
+units yourself, strictly one unit per turn, persisting the report and updating the
+worklist before starting the next.
+
+Every delegation restates for the scout (its rule file may not be loaded in a fresh
+context; `.claude/rules/architecture-map.md` stays authoritative): write only
+`.sdd-scan/reports/<unit-slug>.md`, in `DocLanguage` from `AGENTS.md`; return at most
+five summary lines; and the report schema — Purpose (2 sentences) · Entry points
+(exact paths) · Internal pattern (path patterns, e.g. "Application/<Feature>/ holds
+Command + Handler + Validator") · Dependencies in/out (concrete contract or event
+files) · Deviations from repo conventions · Traps and frozen zones · Observed,
+undocumented decisions (candidates for systemPatterns.md).
+
+**Split rule:** a unit that is not coherent and graspable (heuristic: no single
+recognizable pattern, or clearly beyond ~150 relevant files) gets no shallow report —
+the scout returns a structural note plus proposed child units instead; add them to
+the worklist with Parent and Depth, mark the unit `split`. Depth is capped at 3;
+beyond that, ask the user. After every scout return, update the worklist **in the
+same change set** — a report whose worklist row did not move is not done.
+
+## Phase C — Synthesis (reduce) and distillation
+
+Bottom-up: when all children of a node are done, merge their reports into one report
+for that node — keep only what is decision-relevant at that level, replace child
+details with the pattern they share — until the root report is the big picture.
+
+Curation MUSTs for everything that survives: nothing an agent can infer from the code
+in seconds; path patterns over path lists; every documented command was executed once
+(commands that reach the network, such as package restores, fall under the ask-first
+rule in `AGENTS.md` — ask, or mark the command unverified); the *why* behind observed
+decisions goes, dated and source-linked, to `.memory-bank/systemPatterns.md`; stack,
+build, run and test facts go to `.memory-bank/techContext.md`. Everything curated —
+snapshot wording, module maps, Memory Bank entries — is written in `DocLanguage` from
+`AGENTS.md`.
+
+**Budget cascade:** target the `architecture:` snapshot alone. Measure against the
+cap in `.claude/rules/constitution.md`. Only when eviction would hit navigation
+facts, move per-module detail to `.architecture/<unit>.md` (≤ 40 lines each — this
+restates `.claude/rules/architecture-map.md`, which is authoritative) and keep in the
+snapshot one line and a `map:` reference per module, plus `coverage:` and an
+`unmapped:` list instructing agents to explore carefully there and propose a worklist
+entry.
+
+## Self-test before hand-off
+
+Compose ten navigation questions ("Where do you add/change X?") across the mapped
+units. Answer each in writing using **only** your distilled result — no file access —
+then verify each against the repository and score. Fix the fingerprint for every
+miss you can, and carry the final score into the delta report.
+
+## Hand-off, then cleanup
+
+Never write the snapshot here. Run the `/sdd-architecture-update` workflow exactly as
+if the user had typed it (its body lives in
+`.claude/commands/sdd-architecture-update.md`), with your distilled findings as the
+observed state; its confirmation gate remains the snapshot's only write gate. After a
+confirmed merge, set `last deep scan` in the snapshot comment via that same update,
+then ask once: "Delete the raw analysis in `.sdd-scan/`? (recommended)".

--- a/.claude/commands/sdd-architecture-scan.md
+++ b/.claude/commands/sdd-architecture-scan.md
@@ -14,11 +14,38 @@ disable-model-invocation: true
 The user may name a focus path after the command; then every phase below applies to
 that subtree only, and the final merge touches only its entries.
 
+Speak plainly, in `DocLanguage`, throughout: assume the user has never seen this
+workflow. Every question and every gate opens with one short line saying why it is
+asked and what the answer changes, and every term of art (worklist, unit, tier,
+scout) gets a one-clause introduction on first use. Minimal and precise — one line
+of why, never a lecture.
+
 ## Where am I? (state router — the files decide, not the conversation)
 
 - No `.sdd-scan/_worklist.md` → run **Phase A**, then stop at the worklist gate.
 - Worklist exists with pending units → run **Phase B** on pending units only.
 - All units done, or the user says "distill what we have" → run **Phase C**.
+
+## On a fresh start — say what this buys and costs (once, in `DocLanguage`)
+
+On a fresh start (no worklist yet) this briefing is the **first visible output** —
+before any question and before Phase A runs, and equally when `/sdd-setup` routed
+here. Three short, plain points (~6 lines total), then proceed:
+
+- **Value:** the fingerprint replaces exploration. Agents in every later session — in both
+  tools — jump straight to the right place instead of searching, and technical planning
+  (specs, reviews, onboarding) starts from a shared, verified map.
+- **Cost:** the scan is token-intensive — scouts read code in isolated contexts. Name a
+  planning figure (~50k tokens per analysis unit; large repositories multiply), say that
+  cost scales with the models in use and can get expensive, and that a capable model pays
+  off for synthesis while the scouts inherit the session model — choosing a cheaper model
+  for the scan session, or pinning one locally in the scout agent files, is the biggest
+  cost lever.
+- **Levers:** the worklist gate is the cost dial — defer units (they stay visible under
+  `unmapped:`), set `shallow` tiers for periphery, rescan later with a focus path; the
+  scan resumes from its files at any point.
+
+Never repeat this on a resume.
 
 ## Phase A — Inventory (git only, no other tooling assumed)
 
@@ -27,46 +54,122 @@ folder); `git ls-files '*.sln' '*.csproj' '**/package.json' '**/pom.xml' '**/go.
 '**/Cargo.toml' '**/pyproject.toml'` (manifests → stack and project graph); per
 candidate source folder `git rev-list --count --since="6 months ago" HEAD -- <folder>`
 (change frequency → priority); read CI configs and test scripts found via `git
-ls-files`. Write `.sdd-scan/_inventory.md` — facts only, no interpretation. Then
+ls-files`. If the repository's own toolchain can print the project graph with commands
+that only read project files — no network, no install or restore (e.g. `dotnet sln
+list` plus `dotnet list <project> reference`, or workspace declarations straight from
+the manifests) — run them here and record the graph in the inventory; when unsure
+whether a command is that harmless, skip it — the git inventory carries alone.
+Inventory commands are Phase A's job, exactly as command verification is Phase C's
+gated job; scouts never run any. Write `.sdd-scan/_inventory.md` — facts only, no
+interpretation. Then
 propose analysis units (modules, bounded contexts, projects) with priorities as
 `.sdd-scan/_worklist.md`: a table with columns #, Unit, Path, Parent, Depth, Priority,
-Status (pending | split | done | synthesized), Report.
+Tier (deep | standard | shallow), Status (pending | split | done | synthesized), Report.
+Propose `deep` when churn is high **or** centrality is high (many incoming references) —
+a low-churn shared kernel or contracts folder is a root, not periphery. Propose shared
+or contract-like locations (shared kernels, contract folders, cross-service event
+definitions, service defaults) as their own high-priority units — each seam is then
+read deeply by exactly one scout and only referenced by its neighbours.
+
+Cut coarse-first: ~10–15 units for a mid-size repository is the anchor, and the
+operative test is that a unit can carry its own ≤ 120-line report with its own
+pattern — a unit whose report would mostly repeat a sibling's patterns, or describe
+no behavior at all (assets, generated output, lock artifacts), is not a unit: fold
+it in, one inventory line suffices. The asymmetry is why coarse wins: too coarse
+self-heals (the split rule fires on evidence — a bursting report budget is the
+proof), while too fine has no merge trigger at runtime and only the bill notices.
+Where the project graph was extracted, it is the primary cut input: one unit per
+weakly coupled subgraph, not one per folder.
 
 ## Worklist gate (the only gate this command adds)
 
-Present the proposed units and priorities. Unit boundaries need human interpretation:
-say what you guessed, ask what to merge, split or defer, apply the answer, mark the
-worklist confirmed. Never proceed on an unconfirmed worklist.
+Open the gate in plain words: one line on what this list is (the scan's work plan —
+which parts of the code get how much attention), one line on why the user decides
+(boundaries and depth are judgment calls, and deeper costs more). Then present the
+proposed units, priorities and tiers, state the cost of the cut explicitly ("N units
+≈ N/3 scout rounds at the default cap"), and offer the plain default ("answer OK to
+accept the proposal"). Say what you guessed, ask what to merge, split, defer or
+re-tier, apply the answer, mark the worklist confirmed. Never proceed on an
+unconfirmed worklist.
 
 ## Phase B — Scouts (map)
 
 If your environment can delegate work to an isolated agent with its own context
 window — both supported tools can, via the repository's `sdd-scout` agent definition —
-dispatch one scout per pending unit, at most three in parallel. If it cannot, do the
-units yourself, strictly one unit per turn, persisting the report and updating the
-worklist before starting the next.
+dispatch one scout per pending unit, at most three in parallel — a declared default,
+not a correctness condition: the worklist makes any degree of parallelism safe; the
+cap protects the permission-prompt experience and the tools' concurrency limits, and
+an explicit user request ("run up to N scouts") overrides it. If your environment
+cannot delegate, do the units yourself, strictly one unit per turn, persisting the
+report and updating the worklist before starting the next.
 
 Every delegation restates for the scout (its rule file may not be loaded in a fresh
 context; `.claude/rules/architecture-map.md` stays authoritative): write only
 `.sdd-scan/reports/<unit-slug>.md`, in `DocLanguage` from `AGENTS.md`; return at most
-five summary lines; and the report schema — Purpose (2 sentences) · Entry points
+five summary lines; the report schema — Purpose (2 sentences) · Entry points
 (exact paths) · Internal pattern (path patterns, e.g. "Application/<Feature>/ holds
 Command + Handler + Validator") · Dependencies in/out (concrete contract or event
 files) · Deviations from repo conventions · Traps and frozen zones · Observed,
-undocumented decisions (candidates for systemPatterns.md).
+undocumented decisions (candidates for systemPatterns.md); and the leaf-report
+budget — the schema in ≤ 120 lines, where an honest report that cannot fit is the
+split rule firing, never a reason to compress harder.
 
-**Split rule:** a unit that is not coherent and graspable (heuristic: no single
-recognizable pattern, or clearly beyond ~150 relevant files) gets no shallow report —
+<!-- Authority split, on purpose: procedural rules — the read ladder, the full-read
+     caps and the audit header lines — are owned HERE in the delegation block. The
+     artifact budgets (≤120-line report, ≤40-line map) and the report schema are owned
+     by .claude/rules/architecture-map.md. Do not unify the two homes. -->
+
+Every delegation also carries the working discipline; it binds scouts and the
+sequential fallback alike. The read ladder: **locate first** — if your environment
+offers a code outline, symbol index, or workspace/semantic search, use it to locate
+candidates before reading, treating its results as hints to verify by reading, never
+as facts; without such an index, locate via glob and grep (naming patterns,
+registrations, contracts). **Head-read is the default**: the first ~60 lines or an
+outline — imports, namespace, signatures, doc comment. **Full reads only on
+trigger**, of two kinds: mandatory (entry points, the composition root,
+contracts/events, and one representative per recognized pattern) and uncertainty
+(the head contradicts the hypothesis, name and content disagree, trap suspicion).
+A name is a hypothesis; the head is the test — never state a role derived from a
+name or path without confirming it in content, and record every name↔content
+mismatch as a trap finding: it is high-value fingerprint material. Stop reading when
+a new file no longer changes the report.
+
+Full reads are budgeted: the delegation names the unit's tier and assigns the cap
+(standard 10 · seam/deep up to 20 · shallow ≤ 3), and the report header carries
+`tier:` plus the audit line `full reads: n/cap`. Overflow against an assigned budget
+is the split rule firing — never silence, never compression. A shallow unit still
+reads heads, never names alone: minimum is the manifest plus the heads of the three
+to five most-referenced files.
+
+Read and search only; run no commands and build nothing — the scan stays
+reproducible and side-effect-free, and command verification is Phase C's gated job.
+Beyond the unit's own paths, record the touchpoint file as a dependency and stop —
+the neighbour's inside belongs to the neighbour's scout. Include the siblings'
+worklist rows (unit, path, one-line purpose), so the scout knows where its unit
+ends — and, when Phase A extracted a project graph, the unit's own graph digest:
+its in/out edges plus the top-level shape, never the full graph, passed as located
+hints to verify by reading, never as facts. A runtime coupling the static graph
+does not show is a trap finding — the graph↔runtime sibling of the name↔content
+rule.
+
+**Split rule:** a unit that is not coherent and graspable (heuristics: no single
+recognizable pattern, clearly beyond ~150 relevant files, or an honest report that
+will not fit the ≤ 120-line budget) gets no shallow report —
 the scout returns a structural note plus proposed child units instead; add them to
 the worklist with Parent and Depth, mark the unit `split`. Depth is capped at 3;
 beyond that, ask the user. After every scout return, update the worklist **in the
-same change set** — a report whose worklist row did not move is not done.
+same change set** — a report whose worklist row did not move is not done, and a
+report missing its `tier:` and `full reads: n/cap` header lines is equally not
+done: complete the header from the scout's return (or re-ask) before marking the
+row.
 
 ## Phase C — Synthesis (reduce) and distillation
 
 Bottom-up: when all children of a node are done, merge their reports into one report
 for that node — keep only what is decision-relevant at that level, replace child
 details with the pattern they share — until the root report is the big picture.
+Where two reports describe the same seam differently, the contradiction is a
+synthesis finding to resolve here — not a scout error.
 
 Curation MUSTs for everything that survives: nothing an agent can infer from the code
 in seconds; path patterns over path lists; every documented command was executed once
@@ -75,22 +178,40 @@ rule in `AGENTS.md` — ask, or mark the command unverified); the *why* behind o
 decisions goes, dated and source-linked, to `.memory-bank/systemPatterns.md`; stack,
 build, run and test facts go to `.memory-bank/techContext.md`. Everything curated —
 snapshot wording, module maps, Memory Bank entries — is written in `DocLanguage` from
-`AGENTS.md`.
+`AGENTS.md`, and that includes the snapshot's own values, not just prose around them.
+The snapshot obeys the same curation bar: every `entrypoints:`/`modules:` line carries
+its path plus a one-clause purpose or trap — never a bare path. A snapshot that a
+directory listing could have produced is not a fingerprint.
 
 **Budget cascade:** target the `architecture:` snapshot alone. Measure against the
 cap in `.claude/rules/constitution.md`. Only when eviction would hit navigation
 facts, move per-module detail to `.architecture/<unit>.md` (≤ 40 lines each — this
 restates `.claude/rules/architecture-map.md`, which is authoritative) and keep in the
-snapshot one line and a `map:` reference per module, plus `coverage:` and an
-`unmapped:` list instructing agents to explore carefully there and propose a worklist
-entry.
+snapshot one line and a `map:` reference per module, plus `coverage:` — counting
+shallow-tier units separately, e.g. "9/14 mapped (2 shallow)" — and an `unmapped:`
+list instructing agents to explore carefully there and propose a worklist entry.
+Shallow-tier units carry the matching instruction: their facts are head-derived —
+verify before relying on them, and on first real contact propose a deepening
+worklist entry.
 
 ## Self-test before hand-off
 
+The self-test is **mandatory** — the hand-off below stays blocked until its score
+and the surface-cue probe's outcome are recorded for the delta report. A distilled
+result that cannot answer navigation questions is not ready to become the snapshot.
+
 Compose ten navigation questions ("Where do you add/change X?") across the mapped
-units. Answer each in writing using **only** your distilled result — no file access —
-then verify each against the repository and score. Fix the fingerprint for every
-miss you can, and carry the final score into the delta report.
+**deep and standard** units — shallow units are excluded from the score. Answer each
+in writing using **only** your distilled result — no file access — then verify each
+against the repository and score. Fix the fingerprint for every miss you can, and
+carry the final score into the delta report.
+
+Then run the surface-cue probe: while composing the questions, mark which snapshot
+claims would be plausible from names alone, pick one deliberately — prefer a shallow
+unit — and verify it against file contents. A mismatch is a hard fail independent of
+the score: correct the fingerprint, then repeat the probe. A name-derived error in
+the fingerprint is multiplicative poison — every later session trusts it with the
+authority this document exists to carry.
 
 ## Hand-off, then cleanup
 

--- a/.claude/commands/sdd-architecture-scan.md
+++ b/.claude/commands/sdd-architecture-scan.md
@@ -24,7 +24,11 @@ of why, never a lecture.
 
 - No `.sdd-scan/_worklist.md` → run **Phase A**, then stop at the worklist gate.
 - Worklist exists with pending units → run **Phase B** on pending units only.
-- All units done, or the user says "distill what we have" → run **Phase C**.
+- All units done but the update merge not yet confirmed → run **Phase C**. The user
+  saying "distill what we have" also runs **Phase C** — a full re-distillation from
+  the reports, even after a confirmed merge; refreshing dates or markers alone is
+  not a distillation. Otherwise, after a confirmed merge, a re-invocation has
+  nothing left but the cleanup question.
 
 ## On a fresh start — say what this buys and costs (once, in `DocLanguage`)
 
@@ -65,6 +69,7 @@ interpretation. Then
 propose analysis units (modules, bounded contexts, projects) with priorities as
 `.sdd-scan/_worklist.md`: a table with columns #, Unit, Path, Parent, Depth, Priority,
 Tier (deep | standard | shallow), Status (pending | split | done | synthesized), Report.
+Inventory and worklist are written in `DocLanguage`, like every scan artifact.
 Propose `deep` when churn is high **or** centrality is high (many incoming references) —
 a low-churn shared kernel or contracts folder is a root, not periphery. Propose shared
 or contract-like locations (shared kernels, contract folders, cross-service event
@@ -86,9 +91,10 @@ weakly coupled subgraph, not one per folder.
 Open the gate in plain words: one line on what this list is (the scan's work plan —
 which parts of the code get how much attention), one line on why the user decides
 (boundaries and depth are judgment calls, and deeper costs more). Then present the
-proposed units, priorities and tiers, state the cost of the cut explicitly ("N units
-≈ N/3 scout rounds at the default cap"), and offer the plain default ("answer OK to
-accept the proposal"). Say what you guessed, ask what to merge, split, defer or
+proposed units, priorities and tiers, state the cost of the cut explicitly and in plain outcome terms ("N areas ≈
+N/3 analysis rounds — more depth means more time and tokens"; if you use the word
+scout, introduce it in one clause: an isolated reading agent covering one area), and
+offer the plain default ("answer OK to accept the proposal"). Say what you guessed, ask what to merge, split, defer or
 re-tier, apply the answer, mark the worklist confirmed. Never proceed on an
 unconfirmed worklist.
 
@@ -183,11 +189,18 @@ The snapshot obeys the same curation bar: every `entrypoints:`/`modules:` line c
 its path plus a one-clause purpose or trap — never a bare path. A snapshot that a
 directory listing could have produced is not a fingerprint.
 
-**Budget cascade:** target the `architecture:` snapshot alone. Measure against the
-cap in `.claude/rules/constitution.md`. Only when eviction would hit navigation
-facts, move per-module detail to `.architecture/<unit>.md` (≤ 40 lines each — this
-restates `.claude/rules/architecture-map.md`, which is authoritative) and keep in the
-snapshot one line and a `map:` reference per module, plus `coverage:` — counting
+**Maps and the snapshot budget — deterministic, no judgment calls:** every **deep**
+unit gets a curated map `.architecture/<unit>.md` (≤ 40 lines each — this restates
+`.claude/rules/architecture-map.md`, which is authoritative) holding its inside view:
+internal path patterns, the registration file, the task playbook. Deep tier means the
+map exists — there is no "it fits in the snapshot" exception. A standard unit gets a
+map only when its snapshot line cannot answer "where exactly inside"; shallow units
+never do. The snapshot keeps exactly **one YAML list item per module and per
+entrypoint** — path, one purpose clause, and a `map:` reference where a map exists;
+never concatenate several entries into one line to save lines — the cap in
+`.claude/rules/constitution.md` is managed by this cascade, not by line-packing. A
+fingerprint whose deep units are only navigable at project granularity is not
+finished. Keep `coverage:` — counting
 shallow-tier units separately, e.g. "9/14 mapped (2 shallow)" — and an `unmapped:`
 list instructing agents to explore carefully there and propose a worklist entry.
 Shallow-tier units carry the matching instruction: their facts are head-derived —
@@ -201,7 +214,11 @@ and the surface-cue probe's outcome are recorded for the delta report. A distill
 result that cannot answer navigation questions is not ready to become the snapshot.
 
 Compose ten navigation questions ("Where do you add/change X?") across the mapped
-**deep and standard** units — shallow units are excluded from the score. Answer each
+**deep and standard** units — shallow units are excluded from the score. At least
+half of the questions must target locations **inside** units — a file or a subfolder
+pattern ("where do I add a new integration event", "which file registers a
+handler") — because a question answerable by naming a project proves nothing about
+navigation depth. Answer each
 in writing using **only** your distilled result — no file access — then verify each
 against the repository and score. Fix the fingerprint for every miss you can, and
 carry the final score into the delta report.
@@ -220,4 +237,5 @@ if the user had typed it (its body lives in
 `.claude/commands/sdd-architecture-update.md`), with your distilled findings as the
 observed state; its confirmation gate remains the snapshot's only write gate. After a
 confirmed merge, set `last deep scan` in the snapshot comment via that same update,
-then ask once: "Delete the raw analysis in `.sdd-scan/`? (recommended)".
+then ask once, rendered in `DocLanguage`: "Delete the raw analysis in `.sdd-scan/`?
+(recommended)".

--- a/.claude/commands/sdd-architecture-update.md
+++ b/.claude/commands/sdd-architecture-update.md
@@ -51,7 +51,8 @@ Only after confirmation:
 
 - Update the `architecture:` YAML in `AGENTS.md` (the only place it lives), and set the
   `# last reconciled:` comment inside that block to today's date — a snapshot with no date
-  cannot be told apart from one that was never checked.
+  cannot be told apart from one that was never checked. Snapshot **values** are written in
+  `DocLanguage`, one YAML list item per entry.
 - When `.architecture/` exists, update the affected module map(s) and their
   `# last reconciled:` lines in the same change set.
 - Update `.memory-bank/systemPatterns.md` (patterns/decisions).
@@ -67,6 +68,11 @@ Treat the scan's distilled findings as the observed state; include its coverage 
 navigation self-test score in the delta report; on confirmation also set `last deep scan` in
 the snapshot comment. The gate above stays the snapshot's only write gate. If the findings
 arrive without a recorded self-test score, do not open the gate — send the scan back to run
-its self-test first: an unverified fingerprint is not observed state.
+its self-test first: an unverified fingerprint is not observed state. On confirmation the
+distilled findings replace the snapshot's **values**, not just its structure: wording,
+`DocLanguage` and the per-line purpose clauses count as drift, so "the paths are the same"
+is never a reason to keep weaker values. Persist the self-test score in the snapshot's
+`coverage:` line, and write nothing outside this gate's sync list — the constitution's own
+wiring prose is not a reconciliation target.
 
 Everything must remain **DocLanguage-aware**.

--- a/.claude/commands/sdd-architecture-update.md
+++ b/.claude/commands/sdd-architecture-update.md
@@ -65,6 +65,8 @@ Only after confirmation:
 
 Treat the scan's distilled findings as the observed state; include its coverage figures and
 navigation self-test score in the delta report; on confirmation also set `last deep scan` in
-the snapshot comment. The gate above stays the snapshot's only write gate.
+the snapshot comment. The gate above stays the snapshot's only write gate. If the findings
+arrive without a recorded self-test score, do not open the gate — send the scan back to run
+its self-test first: an unverified fingerprint is not observed state.
 
 Everything must remain **DocLanguage-aware**.

--- a/.claude/commands/sdd-architecture-update.md
+++ b/.claude/commands/sdd-architecture-update.md
@@ -32,6 +32,14 @@ reconcile them.
 3. Present a **delta report**: what changed (observed), why it matters (brief), and the
    proposed updates to the snapshot and Memory Bank docs.
 
+## When reconciliation is not enough
+
+If the tree shows several structures the snapshot cannot place, the snapshot names paths that
+no longer exist, or the focus area sits under `unmapped:` — do not guess. Recommend
+`/sdd-architecture-scan` (with the focus path) in the delta report instead. (This spells out
+the escalation rule from `AGENTS.md` for the moment this command acts; `AGENTS.md` stays
+authoritative.)
+
 ## Confirmation gate
 
 Before writing anything, ask:
@@ -44,11 +52,19 @@ Only after confirmation:
 - Update the `architecture:` YAML in `AGENTS.md` (the only place it lives), and set the
   `# last reconciled:` comment inside that block to today's date — a snapshot with no date
   cannot be told apart from one that was never checked.
+- When `.architecture/` exists, update the affected module map(s) and their
+  `# last reconciled:` lines in the same change set.
 - Update `.memory-bank/systemPatterns.md` (patterns/decisions).
 - Update `.memory-bank/techContext.md` when stack, build or test facts changed.
 - Update `.memory-bank/activeContext.md` (recent changes + next steps; size limit from
   `AGENTS.md`).
 - Measure `AGENTS.md` against the cap in `.claude/rules/constitution.md`; if over, propose an
   eviction per its order.
+
+## When invoked from /sdd-architecture-scan
+
+Treat the scan's distilled findings as the observed state; include its coverage figures and
+navigation self-test score in the delta report; on confirmation also set `last deep scan` in
+the snapshot comment. The gate above stays the snapshot's only write gate.
 
 Everything must remain **DocLanguage-aware**.

--- a/.claude/commands/sdd-overview.md
+++ b/.claude/commands/sdd-overview.md
@@ -23,6 +23,7 @@ Inspect the workspace and report, in `DocLanguage`:
 - The `DocLanguage` value from `AGENTS.md`.
 - Which specs sit in `.specs/backlog/`, `.specs/active/`, and `.specs/done/` (list the files;
   say "(none)" for an empty folder).
+- If the snapshot comment names a `last deep scan` date: report it plus the count of `unmapped:` entries.
 - Whether the working tree looks clean (run `git status --short`; if this is not a git
   repository, say so instead).
 

--- a/.claude/commands/sdd-setup.md
+++ b/.claude/commands/sdd-setup.md
@@ -72,14 +72,20 @@ Ask exactly: **"In which language should the project documentation Markdown file
 Run `git ls-files` and count source files outside this template's own folders
 (`.claude/`, `.github/`, `.specs/`, `.memory-bank/`, `.vscode/`). Guess the mode —
 substantial source files plus a snapshot still at `TBD` or `# last reconciled: never`
-suggests existing software — state your guess, then ask exactly:
+suggests existing software — state your guess, then ask exactly this question,
+rendered in `DocLanguage`:
 **"Is this a new project, or existing software we are adopting?"**
 
 - **New project** → continue with this wizard unchanged.
-- **Existing software** → ask what is needed right now: documentation language and
-  Memory Bank seeding only, or a deep architecture scan that builds the fingerprint
-  from the code (token-intensive — the scan states its value, cost and levers before it
-  starts). If the scan is chosen: first collect wizard steps 1, 2 and 7 (only
+- **Existing software** → present the choice as a short plain-language briefing in
+  `DocLanguage` (~5 lines), and **recommend the deep architecture scan**: it builds
+  the architecture fingerprint from the code, and with it agents jump straight to the
+  right files instead of searching — cheaper and faster in every later session, higher
+  quality, fewer wrong assumptions, and technical planning starts from a shared map.
+  Say honestly that the scan reads code and, depending on project size, takes time and
+  noticeable tokens. Name the alternatives: describe the architecture yourself, or
+  seed only the Memory Bank now and scan later. If the scan is chosen: first collect
+  wizard steps 1, 2 and 7 (only
   the human knows mission, audience and taste), then run the `/sdd-architecture-scan`
   workflow yourself, exactly as if the user had typed it (its body lives in
   `.claude/commands/sdd-architecture-scan.md`). Skip wizard steps 3–6 — the scan

--- a/.claude/commands/sdd-setup.md
+++ b/.claude/commands/sdd-setup.md
@@ -65,6 +65,24 @@ Ask exactly: **"In which language should the project documentation Markdown file
 - Then write all project docs (Memory Bank + specs) in that language, rewriting the default
   English templates if needed.
 
+## Step 1 (MUST follow Step 0): Project mode
+
+Run `git ls-files` and count source files outside this template's own folders
+(`.claude/`, `.github/`, `.specs/`, `.memory-bank/`, `.vscode/`). Guess the mode —
+substantial source files plus a snapshot still at `TBD` or `# last reconciled: never`
+suggests existing software — state your guess, then ask exactly:
+**"Is this a new project, or existing software we are adopting?"**
+
+- **New project** → continue with this wizard unchanged.
+- **Existing software** → ask what is needed right now: documentation language and
+  Memory Bank seeding only, or a deep architecture scan that builds the fingerprint
+  from the code. If the scan is chosen: first collect wizard steps 1, 2 and 7 (only
+  the human knows mission, audience and taste), then run the `/sdd-architecture-scan`
+  workflow yourself, exactly as if the user had typed it (its body lives in
+  `.claude/commands/sdd-architecture-scan.md`). Skip wizard steps 3–6 — the scan
+  answers them from the code and writes `techContext.md` and `systemPatterns.md`
+  itself. Afterwards finish only actions B (projectbrief + activeContext), D and E.
+
 ## Read the repo before asking
 
 Manifests and lock files (stack, package manager) · the tree's top two levels (entrypoints,

--- a/.claude/commands/sdd-setup.md
+++ b/.claude/commands/sdd-setup.md
@@ -64,6 +64,8 @@ Ask exactly: **"In which language should the project documentation Markdown file
 - After a language is chosen, set `DocLanguage` in `AGENTS.md` (the **only** place it lives).
 - Then write all project docs (Memory Bank + specs) in that language, rewriting the default
   English templates if needed.
+- From here on, conduct the entire dialogue — every question, confirmation and summary —
+  in `DocLanguage`. Only this template's own files stay English.
 
 ## Step 1 (MUST follow Step 0): Project mode
 
@@ -76,7 +78,8 @@ suggests existing software — state your guess, then ask exactly:
 - **New project** → continue with this wizard unchanged.
 - **Existing software** → ask what is needed right now: documentation language and
   Memory Bank seeding only, or a deep architecture scan that builds the fingerprint
-  from the code. If the scan is chosen: first collect wizard steps 1, 2 and 7 (only
+  from the code (token-intensive — the scan states its value, cost and levers before it
+  starts). If the scan is chosen: first collect wizard steps 1, 2 and 7 (only
   the human knows mission, audience and taste), then run the `/sdd-architecture-scan`
   workflow yourself, exactly as if the user had typed it (its body lives in
   `.claude/commands/sdd-architecture-scan.md`). Skip wizard steps 3–6 — the scan
@@ -92,6 +95,9 @@ for what you can read: pre-fill steps 3, 5 and 6 below from what you found and p
 for correction in one turn. On a re-run, merge with what exists — never reset a curated file.
 
 ## Wizard steps (ask only what the repo did not answer)
+
+Every question carries one short clause of why it is asked (what it seeds) — plain
+language, no lecture.
 
 1. **Project name & one-liner**
 2. **Primary users / target audience**

--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -16,6 +16,19 @@ only when the snapshot cap would otherwise evict navigation facts. The snapshot 
 - Keep each map's `# last reconciled:` line current — `/sdd-architecture-update`
   maintains it when structure drifts.
 
+## Scout reports (`.sdd-scan/reports/`)
+
+Raw per-unit reports from `/sdd-architecture-scan`'s Phase B follow the schema, in order:
+Purpose (2 sentences) · Entry points (exact paths) · Internal pattern (path patterns) ·
+Dependencies in/out (concrete contract or event files) · Deviations from repo
+conventions · Traps and frozen zones · Observed, undocumented decisions.
+
+- Budget: a leaf report fits the schema in **≤ 120 lines**. If an honest report cannot,
+  that is the split rule firing — a structural note plus proposed child units, never
+  harder compression.
+- Three nested budgets, three purposes: ≤ 5 return lines protect the orchestrator ·
+  ≤ 120 report lines protect the synthesis · ≤ 40 map lines protect the end artifact.
+
 > Note: path-scoped rules load when a matching file is **read**. A brand-new map has
 > not been read yet, so `/sdd-architecture-scan` restates the schema and these budgets
 > inline — that restatement is labelled and this file stays authoritative.

--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -1,0 +1,21 @@
+---
+paths:
+  - .architecture/**/*.md
+---
+
+# Architecture map writing rules
+
+`.architecture/` holds curated per-module maps, created by `/sdd-architecture-scan`
+only when the snapshot cap would otherwise evict navigation facts. The snapshot in
+`AGENTS.md` stays the inventory; a map holds one module's inside view.
+
+- Write in `DocLanguage` from `AGENTS.md`. Budget: ≤ 40 lines per map.
+- Content, in order: internal pattern as path patterns · entry points · task
+  playbooks ("when doing X: files A → B → C; never Y") · deviations · traps.
+- Nothing an agent can infer from the code in seconds; path patterns over path lists.
+- Keep each map's `# last reconciled:` line current — `/sdd-architecture-update`
+  maintains it when structure drifts.
+
+> Note: path-scoped rules load when a matching file is **read**. A brand-new map has
+> not been read yet, so `/sdd-architecture-scan` restates the schema and these budgets
+> inline — that restatement is labelled and this file stays authoritative.

--- a/.claude/rules/constitution.md
+++ b/.claude/rules/constitution.md
@@ -12,7 +12,8 @@ paths:
   cap, evict in this order: (1) anything a command already carries and only needs at the moment
   that command runs, (2) explanatory prose around a rule — keep the rule, drop the essay,
   (3) examples, once one remains. Never evict a rule to a loader file: that is the drift this
-  design exists to prevent. If nothing is left to evict, the constitution has outgrown its job
+  design exists to prevent. And never evict a sentence that states a gate, an ask-first
+  boundary or a non-negotiable — a gate that exists only sometimes is not a gate. If nothing is left to evict, the constitution has outgrown its job
   and the surplus belongs in a path-scoped rule under `.claude/rules/`.
 - `DocLanguage`, the `architecture:` snapshot, and *Style & Output Preferences* live **only**
   here. Never copy them into `CLAUDE.md` or any other loader.

--- a/.github/agents/sdd-scout.agent.md
+++ b/.github/agents/sdd-scout.agent.md
@@ -1,0 +1,17 @@
+---
+name: sdd-scout
+description: Architecture scout used only by /sdd-architecture-scan. Analyzes one worklist unit and writes its report to .sdd-scan/reports/. Not for general tasks.
+tools: ['read', 'search', 'edit']
+user-invocable: false
+---
+
+You are the architecture scout for this repository's `/sdd-architecture-scan`
+workflow. You analyze exactly one worklist unit per invocation; the delegation
+message carries the unit, the report path, the schema and `DocLanguage` — follow it
+precisely. Write only inside `.sdd-scan/reports/`. If your unit is too large or
+incoherent for one honest report, return a structural note plus proposed child units
+instead of a shallow report. Return at most five summary lines.
+
+<!-- This file exists twice on purpose (Claude dialect in .claude/agents/sdd-scout.md,
+     VS Code dialect in .github/agents/sdd-scout.agent.md): the frontmatter languages
+     differ, the body is the shared single source. Change both together. -->

--- a/.github/agents/sdd-scout.agent.md
+++ b/.github/agents/sdd-scout.agent.md
@@ -8,7 +8,9 @@ user-invocable: false
 You are the architecture scout for this repository's `/sdd-architecture-scan`
 workflow. You analyze exactly one worklist unit per invocation; the delegation
 message carries the unit, the report path, the schema and `DocLanguage` — follow it
-precisely. Write only inside `.sdd-scan/reports/`. If your unit is too large or
+precisely. Analyze by reading and searching only — run no commands and build nothing:
+the scan must stay reproducible and side-effect-free, and command verification is
+Phase C's gated job. Write only inside `.sdd-scan/reports/`. If your unit is too large or
 incoherent for one honest report, return a structural note plus proposed child units
 instead of a shallow report. Return at most five summary lines.
 

--- a/.github/prompts/sdd-architecture-scan.prompt.md
+++ b/.github/prompts/sdd-architecture-scan.prompt.md
@@ -1,0 +1,13 @@
+---
+name: sdd-architecture-scan
+description: Deep architecture scan — recursively analyze an existing codebase into the fingerprint. Resumable; safe to re-run anytime.
+argument-hint: "[focus path] (optional)"
+---
+
+# /sdd-architecture-scan
+
+Follow [`.claude/commands/sdd-architecture-scan.md`](../../.claude/commands/sdd-architecture-scan.md) exactly — read that file
+first and treat it as your instructions for this turn. It is the single source for this
+workflow; this file only points at it and holds no rules of its own.
+
+Anything the user typed after the command is the argument the workflow refers to.

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,3 @@ CLAUDE.local.md
 
 # Volatile deep-scan working state — deleting it loses nothing curated
 .sdd-scan/
-
-# Local validation notes for developing this template — never shipped
-validation/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 .claude/settings.local.json
 CLAUDE.local.md
 .github/copilot/settings.local.json
+
+# Volatile deep-scan working state — deleting it loses nothing curated
+.sdd-scan/
+
+# Local validation notes for developing this template — never shipped
+validation/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,5 @@
   "chat.useClaudeMdFile": false,
   "chat.instructionsFilesLocations": { ".claude/rules": true },
   "chat.promptFilesLocations": { ".github/prompts": true },
-  "chat.agentFilesLocations": { ".github/agents": true, ".claude/agents": true }
+  "chat.agentFilesLocations": { ".github/agents": true, ".claude/agents": false }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,14 +14,11 @@ You are the **Spec-Driven Development (SDD)** assistant for this repository. Wor
 
 Everything mutable lives **here in `AGENTS.md` only**: `DocLanguage`, the `architecture:`
 snapshot, and the *Style & Output Preferences* section. Commands that update those write
-to this file. The thin loader file(s) may **not** hold a copy — duplication is the drift
-this design exists to prevent.
+to this file. The thin loader file(s) may **not** hold a copy.
 
-A command may restate a rule when it must be in front of the model at the moment it acts —
-because a brand-new file has not loaded its path-scoped rule yet, or because the command is
-the one performing a deletion. Such a restatement must say that it is one and name its source
-(`AGENTS.md` or the owning `.claude/rules/*` file) as authoritative. Anything else is a copy,
-and copies drift.
+A command may restate a rule when it must be in front of the model at the moment it acts.
+Such a restatement must say that it is one and name its source (`AGENTS.md` or the owning
+`.claude/rules/*` file) as authoritative. Anything else is a copy, and copies drift.
 
 Declared exceptions: `README.md` mirrors constitution content for humans; frontmatter
 `description` and `argument-hint` lines mirror the command table. On divergence this file
@@ -30,21 +27,18 @@ wins.
 ## Repository Settings (managed by /sdd-setup)
 
 ```yaml
-DocLanguage: English # default; /sdd-setup may change this
+DocLanguage: English # default; /sdd-setup may change this. Governs the user's project docs
+                     # (Memory Bank, specs, README); the template's own wiring stays English.
 ```
-
-`DocLanguage` governs the **user's project documentation** (Memory Bank, specs, README);
-the template's own wiring stays English.
 
 ## Non-negotiables
 
 **Always** — prefer small, testable steps over large refactors; keep changes consistent with
 the `architecture:` snapshot below.
 
-**Ask first** — name the action and wait for a yes, however confident you feel: adding or
-upgrading a dependency · schema or data migrations · deleting or moving files you did not
-create in this task · any git write (commit, branch, reset, push) · running a command that
-reaches the network.
+**Ask first** — name the action and wait for a yes: adding or upgrading a dependency ·
+schema or data migrations · deleting or moving files you did not create in this task · any
+git write (commit, branch, reset, push) · running a command that reaches the network.
 
 **Never** — request or include secrets (`.env`, keys, tokens) in chat or code; keep sensitive
 files out of context.
@@ -54,33 +48,30 @@ is not blocking — then state it and record it in the spec's *Assumptions*.
 
 ### Progress & state sync (gate)
 
-The duty to keep the plan and Memory Bank current lives in path-scoped rules that load only when
-their file is open — which is how a step's code can land while its status does not. Stated here,
-it binds every session and any agent. **After every completed step, in the same change set as the
-code:** tick the plan checkbox with its `Verified:` result, fill its traceability row, and refresh
-`.memory-bank/activeContext.md` — code that moved while its plan and Memory Bank did not is an
-unfinished step, however done it looks. **Before reporting any step or the work as "done", run the
-sync check:** plan, `activeContext.md`, and the code must agree; if they diverge the code is the
+This restates the sync duty from the path-scoped plan and Memory Bank rules (they load only
+when their file is open); stated here, it binds every session and any agent. **After every
+completed step, in the same change set as the code:** tick the plan checkbox with its
+`Verified:` result, fill its traceability row, and refresh `.memory-bank/activeContext.md` —
+code that moved while its docs did not is an unfinished step. **Before reporting anything as
+"done":** plan, `activeContext.md` and code must agree; if they diverge the code is the
 truth, so reconcile the docs first, then report.
 
 ### Fast path
 
-A change smaller than the spec that would describe it — a typo, a rename, a config value, a
-one-line fix with an obvious test — is made directly, with no spec and no plan. Say that you
-are taking the fast path. A fast-path fix with regression risk requires a test in the same
-change set — no test, no fast path — and a note in `.memory-bank/activeContext.md`.
-The ceremony is the method's servant, not its point.
+A change smaller than the spec that would describe it (a typo, a config value) is made
+directly, with no spec and no plan. Say that you are taking the fast path. A fast-path fix
+with regression risk requires a test in the same change set — no test, no fast path — and a
+note in `.memory-bank/activeContext.md`.
 
 ## Style & Output Preferences (MUST MAINTAIN)
 
 ### Rule: Preference capture (high priority)
 
 When the user, in any language, states a coding style or output preference, asks for a
-rewrite ("more idiomatic", "without LINQ"), or asks to remember a lasting do or don't
-("no comments from now on", "remember this"): acknowledge briefly, **immediately** record it
-as a bullet below — replacing any bullet it contradicts, and saying so — and follow it
-strictly from then on. Bullets here load in every session; that is what makes them binding.
-This section is never finished.
+rewrite ("more idiomatic"), or asks to remember a lasting do or don't ("no comments from
+now on"): acknowledge briefly, **immediately** record it as a bullet below — replacing any
+bullet it contradicts, and saying so — and follow it strictly from then on. Bullets here
+load in every session; that is what makes them binding. This section is never finished.
 
 ### Current preferences
 
@@ -89,8 +80,7 @@ This section is never finished.
 
 ## Architecture & Design Snapshot (MUST SYNC)
 
-Agents orient by this snapshot — find modules and entrypoints here instead of scanning the
-tree — so it is only useful while it is true.
+Agents orient by this snapshot — find modules and entrypoints here instead of scanning the tree.
 
 ### Rule: Run the architecture update unprompted
 
@@ -99,9 +89,11 @@ not specs, plans or Memory Bank files — or the workspace no longer matches thi
 run the `/sdd-architecture-update` workflow yourself, in the same change set, exactly as if
 the user had typed it (its body lives in `.claude/commands/sdd-architecture-update.md`).
 Typing it manually is the fallback for when this automatic run visibly did not happen.
+When the observed drift is too large to reconcile confidently, or the affected area appears
+under `unmapped:`, recommend `/sdd-architecture-scan` in the delta report instead of guessing.
 
 ```yaml
-# last reconciled: never
+# last reconciled: never · last deep scan: never
 architecture:
   style: 'TBD'
   entrypoints:
@@ -112,36 +104,35 @@ architecture:
     - 'TBD'
 ```
 
+Scan-only locations: `.architecture/` — curated module maps (`map:` references), created
+only by the budget cascade; `.sdd-scan/` — volatile, gitignored, holding nothing curated.
+
 ## Memory Bank (SDD Working Set)
 
 SDD context persists between sessions under `.memory-bank/`:
 
 - `.memory-bank/projectbrief.md` — mission, users, success criteria
 - `.memory-bank/systemPatterns.md` — architecture decisions & patterns
-- `.memory-bank/activeContext.md` — short session dashboard: current focus, active spec,
-  recent changes, decisions in flight, blockers, next steps, validation state
-  (**max 1–2 screen pages, ~60 lines**)
+- `.memory-bank/activeContext.md` — short session dashboard: focus, active spec, recent
+  changes, decisions in flight, blockers, next steps (**max 1–2 screen pages, ~60 lines**)
 - `.memory-bank/techContext.md` — stack, constraints, build/run/test info
 
 **Before continuing existing work, read `.memory-bank/activeContext.md` first** — it links the
-active spec; its plan sits beside it as `NNNN-slug.plan.md`. Read both next. A memory nobody
-retrieves is not a memory.
+active spec; its plan sits beside it as `NNNN-slug.plan.md`. Read both next.
 
 ### Rule: Automatic architecture & memory sync (must)
 
 Whenever you notice architecture-relevant drift (or cause it by editing the repo), update
 the docs **in the same change set**.
 
-**Triggers:** modules or projects added, removed or moved · new top-level folders · new or
-changed entrypoints · build/deploy pipeline changes · boundaries redrawn between modules or
-layers · new architectural decisions or constraints · new user-stated style guidelines
-(→ *Style & Output Preferences*).
+**Triggers:** modules/projects added, removed or moved · new top-level folders · new or
+changed entrypoints · build/deploy pipeline changes · redrawn boundaries · new architectural
+decisions or constraints · new user-stated style guidelines (→ *Style & Output Preferences*).
 
 **Sync targets:** the `architecture:` snapshot — via `/sdd-architecture-update`, run
 unprompted per its rule above; its confirmation gate is the only one · `systemPatterns.md`
-for patterns and decisions · `techContext.md` for stack, build, run and test changes ·
-`activeContext.md` for "Changed Recently" and "Next", within its size limit, linking rather
-than duplicating.
+(patterns, decisions) · `techContext.md` (stack, build, test) · `activeContext.md`
+("Changed Recently" + "Next", within its size limit, linking rather than duplicating).
 
 ## Spec & plan lifecycle
 
@@ -152,7 +143,6 @@ Specs live under `.specs/`, organized by lifecycle stage:
 - `.specs/done/` — implemented specs with passing acceptance criteria
 
 Each spec declares its status near the top:
-
 `**Status:** Draft | In Progress | Implemented | Deprecated | Baseline`
 
 Lifecycle invariants — the move procedure itself lives in `/sdd-lifecycle`:
@@ -170,19 +160,17 @@ Lifecycle invariants — the move procedure itself lives in `/sdd-lifecycle`:
 
 ### Plans
 
-Planning produces a **file**, not just a chat answer. A planned spec has exactly one plan
-beside it, named after the spec with a `.plan.md` suffix — `0007-user-login.md` →
-`0007-user-login.plan.md`. The pair shares a lifecycle folder and always moves together.
+Planning produces a **file**. A planned spec has exactly one plan beside it, named after the
+spec with a `.plan.md` suffix — `0007-user-login.md` → `0007-user-login.plan.md`. The pair
+shares a lifecycle folder and always moves together.
 
 The plan declares its own status near the top:
-
 `**Status:** Not started | In Progress | Blocked | Done`
 
 The plan is the **persisted state of the work**: baby steps, the current step, what each
-finished step touched, and a traceability table from acceptance criteria to steps, code paths
-and the deciding test. Non-negotiable: keep it current **in the same change set as the code**
-— a new session must resume from the plan alone — and keep the chain spec → plan → code → test
-honest; it is how a requirement change finds the code and tests it reaches.
+finished step touched, and a traceability table from acceptance criteria to steps, code
+paths and the deciding test. Keep it current **in the same change set as the code** — a new
+session must resume from the plan alone — and keep the chain spec → plan → code → test honest.
 
 ## Commands
 
@@ -200,6 +188,7 @@ list — commands render it from here.
 | `/sdd-plan` | Spec → persisted baby-step plan file (research, resume, impact analysis) |
 | `/sdd-compile` | Readiness check: verdict, evidence per acceptance criterion, tests, docs sync |
 | `/sdd-architecture-update` | Detect drift, update snapshot + Memory Bank (confirmation gate) |
+| `/sdd-architecture-scan` | Deep, resumable analysis of an existing codebase → fingerprint (first run and refresh) |
 | `/sdd-lifecycle` | Spec status and moves between backlog/active/done |
 | `/sdd-style-update` | Capture coding style preferences into `AGENTS.md` |
 
@@ -207,3 +196,4 @@ Flow — the only source of the recommended order; commands render it from here:
 `/sdd-specify` → `/sdd-clarify` → `/sdd-plan` → human reads the plan → `/sdd-lifecycle`
 (backlog → active) → implement → `/sdd-compile` → `/sdd-lifecycle` (active → done).
 `/sdd-architecture-update` runs unprompted whenever structure drifts; type it only as fallback.
+Brownfield: run `/sdd-architecture-scan` before the first spec.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ wins.
 
 ```yaml
 DocLanguage: English # default; /sdd-setup may change this. Governs the user's project docs
-                     # (Memory Bank, specs, README); the template's own wiring stays English.
+                     # (Memory Bank, specs, README) and all workflow dialogue; wiring stays English.
 ```
 
 ## Non-negotiables

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ criteria, then into a **plan** of baby steps — and only then writes code. Spec
 and progress all live on disk as Markdown in your repository, so the next session, the next
 teammate, and the next tool pick up exactly where you left off.
 
-Nine `/sdd-*` commands drive that loop, and they behave identically in Claude Code and in
+Ten `/sdd-*` commands drive that loop, and they behave identically in Claude Code and in
 GitHub Copilot, because both tools execute the **same files**.
 
 ---
@@ -256,7 +256,7 @@ runs faster because the context is already written down.
 
 ---
 
-## The nine commands
+## The ten commands
 
 | Command | What it does |
 | --- | --- |
@@ -281,7 +281,7 @@ New to it? Just run `/sdd-overview`.
 AGENTS.md              the constitution — rules, doc language, architecture snapshot
 CLAUDE.md              one line: @AGENTS.md
 
-.claude/commands/      the nine workflow bodies (Claude runs them directly)
+.claude/commands/      the ten workflow bodies (Claude runs them directly)
 .claude/rules/         path-scoped craft rules, loaded when a matching file is read
 .claude/settings.json  auto memory off, so the Memory Bank is the only project memory
 .github/prompts/       thin loaders so Copilot reaches the same bodies
@@ -313,7 +313,7 @@ Where a copy exists, it names `AGENTS.md` as the winner.
   it is *not* a default Copilot location, so keep that file if you move these folders into
   another project. FeatherSpec leans on the overlap instead of maintaining two copies.
 - **Workflows are commands, not skills.** A skill advertises itself to the model on every
-  request; a command is only ever run when *you* type it. Nine workflows sitting in every
+  request; a command is only ever run when *you* type it. Ten workflows sitting in every
   system prompt is a cost with no upside here.
 - **Only the entry point differs.** `.claude/commands/<name>.md` holds the body;
   `.github/prompts/<name>.prompt.md` is a thin pointer to it (its frontmatter mirrors the

--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ That is the entire installation. Nothing to build, nothing to run.
 
 ---
 
+## Already have a codebase?
+
+FeatherSpec is not greenfield-only. Run `/sdd-setup` and answer **existing software** — the
+wizard offers a deep architecture scan that reads your code (recursively, with isolated scout
+agents), lets you confirm the module boundaries it found, and distills a lean fingerprint into
+the `architecture:` snapshot. It is resumable at any point, re-runnable whenever the snapshot
+feels stale (`/sdd-architecture-scan`, optionally with a focus path), and it cleans up after
+itself. The full walkthrough lives in the wiki:
+[Adopting an Existing Codebase](https://github.com/GregorBiswanger/featherspec/wiki/Adopting-an-Existing-Codebase).
+
+---
+
 ## The loop
 
 ```mermaid
@@ -256,6 +268,7 @@ runs faster because the context is already written down.
 | `/sdd-compile` | Readiness check: verdict, evidence per acceptance criterion, tests, docs sync |
 | `/sdd-lifecycle` | Move specs between `backlog/`, `active/`, `done/` |
 | `/sdd-architecture-update` | Detect structural drift, update the snapshot (asks first) |
+| `/sdd-architecture-scan` | Deep, resumable scan of an existing codebase → architecture fingerprint |
 | `/sdd-style-update` | Capture a coding-style preference so it sticks |
 
 New to it? Just run `/sdd-overview`.
@@ -272,12 +285,15 @@ CLAUDE.md              one line: @AGENTS.md
 .claude/rules/         path-scoped craft rules, loaded when a matching file is read
 .claude/settings.json  auto memory off, so the Memory Bank is the only project memory
 .github/prompts/       thin loaders so Copilot reaches the same bodies
-.github/agents/        the Copilot persona — a pointer at AGENTS.md, nothing more
+.github/agents/        the Copilot persona, plus the scan's scout agent in VS Code dialect
 .vscode/settings.json  tells Copilot where to find .claude/rules and .github/prompts
 
 .specs/                backlog/ · active/ · done/   — specs + their plan files (ships empty)
 .memory-bank/          projectbrief · systemPatterns · techContext · activeContext
 ```
+
+A deep scan may add one more: `.architecture/` — optional curated per-module maps, created
+only when the snapshot's line cap would otherwise evict navigation detail.
 
 Everything mutable lives in `AGENTS.md` and the two data folders. Workflow bodies exist exactly
 once, under `.claude/commands/`; `.github/prompts/` holds thin pointers to them.


### PR DESCRIPTION
## Brownfield onboarding: `/sdd-architecture-scan` + setup fork

FeatherSpec is no longer greenfield-only. `/sdd-setup` now asks "new project or existing software?" and routes existing codebases into a deep, resumable architecture scan that distills the `architecture:` fingerprint from the code — identically in Claude Code and VS Code Copilot.

**What's inside**
- Setup fork with a plain-language recommendation briefing (value, honest cost warning, alternatives) — the whole dialogue follows `DocLanguage`
- `/sdd-architecture-scan`: git-only inventory (plus optional read-only toolchain graph extraction) → human-confirmed worklist (units, priorities, depth tiers, round-count cost preview) → budgeted scout subagents with a read ladder (locate → head-read default → capped full reads, audited via `tier:` / `full reads: n/cap` report headers) → bottom-up synthesis with a deterministic map rule (deep unit ⇒ `.architecture/<unit>.md`, ≤ 40 lines) → mandatory navigation self-test + surface-cue probe (hard fail) → hand-off to the update gate → cleanup question
- The `sdd-scout` agent ships in both dialects with a byte-identical body, deliberately model-free; the wiki documents model guidance (cheap scouts, reasoning-model synthesis) and the cost envelope
- Constitution hardened: sentences stating gates or non-negotiables are never evictable

**Three design guarantees**
1. **One snapshot write gate** — the scan never writes `architecture:` itself; it ends by running `/sdd-architecture-update` behind its confirmation gate.
2. **Zero greenfield impact** — the classic wizard path is byte-preserved (golden-baseline audited).
3. **Zero always-on context cost** — no skills, `disable-model-invocation: true`; the always-loaded surface stays the < 200-line constitution, and module maps load only when their module is touched.

**Validated on dotnet/eShop** in both tools with uncoached final runs: blind navigation tests **10/10** (Claude Code, map-rich fingerprint) and **8/10** (Copilot, lean fingerprint); a full scan lands at ~340 Copilot credits on a mini model (down from 1,792 before tuning); resumable at every phase from the worklist.

Docs: new README section "Already have a codebase?" + wiki page [Adopting an Existing Codebase](https://github.com/GregorBiswanger/featherspec/wiki/Adopting-an-Existing-Codebase) (wiki push follows the merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)