### PR TITLE
feat(plan): architect persona, quality gates, spec backlink and reactivation path (v1.3.0)

### DIFF
--- a/.claude/commands/sdd-featherspec-update.md
+++ b/.claude/commands/sdd-featherspec-update.md
@@ -428,3 +428,11 @@ entries compose sequentially across skipped versions.
 - slot-edits: managed block gains the `FeatherSpecVersion:` line (written by Phase 7, exempt
   from slot rules) · the `DocLanguage:` line's comment is condensed to one line (value
   untouched)
+
+### 1.3.0 — minor (2026-08-27)
+- adds: architect persona, delegated research grounding, quality-gates line and spec
+  backlink in the plan workflow · reactivation move (done → active) in `/sdd-lifecycle`
+- data-notes: specs gain a `**Plan:**` line under Status (detect: spec without one · offer:
+  insert, linking an existing plan file) · plans gain a `**Quality gates:**` line in
+  Approach (detect: plan without one · offer: per-file insert)
+- probes: `sdd-plan.md` without the architect persona ⇒ ≤1.2.0

--- a/.claude/commands/sdd-lifecycle.md
+++ b/.claude/commands/sdd-lifecycle.md
@@ -53,6 +53,10 @@ Keep the spec set tidy: update status fields, move specs between `backlog/`, `ac
   re-verify, then proceed.
 - **Deprecated:** the spec stays in `done/` and links its successor spec (or
   `successor: none — behaviour removed`); its plan keeps its status plus an abandonment note.
+- **Reactivating an `Implemented` spec** whose behaviour is changing: pair moves back to
+  `active/`, spec and plan both `In Progress`; `/sdd-plan` Mode C extends the plan from its
+  impact report. A new slice of work gets a successor spec instead — when unsure which case
+  it is, ask. `Deprecated` stays reserved for behaviour a successor replaces or removes.
 - **Abandoning a spec that was never implemented:** delete it only on the user's instruction
   and note it in `activeContext.md` — no `Deprecated`, no move to `done/`.
 - **`Baseline` specs** (existing behaviour, brownfield) live in `done/` without a plan and are
@@ -69,7 +73,7 @@ Keep the spec set tidy: update status fields, move specs between `backlog/`, `ac
    the state of the accompanying plan if there is one.
 2. **Propose** a lifecycle update (draft → `backlog/`; in progress → `active/`; completed →
    `done/` with status `Implemented`; invalidated → `Deprecated`, stays in `done/` with a
-   successor link).
+   successor link; changing again → reactivation back to `active/`).
 3. **Act**: edit the `**Status:**` line, move the file — together with its `.plan.md` sibling —
    to the target folder, and delete the originals from the source folder.
 4. **Sync docs**: update the relevant `.memory-bank/*` files. **Always** update

--- a/.claude/commands/sdd-plan.md
+++ b/.claude/commands/sdd-plan.md
@@ -35,7 +35,7 @@ steps to real code.
 ## Mode A — plan from scratch
 
 1. **Read** the spec, `AGENTS.md` (constraints, `architecture:` snapshot, style preferences),
-   and `.memory-bank/techContext.md` plus `systemPatterns.md` — noting the quality gates
+   and `.memory-bank/techContext.md` plus `.memory-bank/systemPatterns.md` — noting the quality gates
    `techContext.md` records (test, build, lint commands). A missing gate is a
    `techContext.md` finding to report, never something to invent.
 2. **Survey the code** the spec touches — entrypoints, the modules named in the snapshot, the

--- a/.claude/commands/sdd-plan.md
+++ b/.claude/commands/sdd-plan.md
@@ -11,6 +11,11 @@ disable-model-invocation: true
 
 # /sdd-plan — Implementation Plan
 
+You are an experienced software architect and tech lead: you turn one reviewed spec into the
+smallest sequence of verifiable steps a developer or an AI coding agent can execute — grounded
+in the repository as it is, the recorded stack, and current, source-backed facts. You decide
+the how; the spec owns the what.
+
 The user may name a spec or plan path after the command. If none is given — or the named path
 does not exist — list what sits under `.specs/` and ask which one to work on.
 
@@ -30,7 +35,9 @@ steps to real code.
 ## Mode A — plan from scratch
 
 1. **Read** the spec, `AGENTS.md` (constraints, `architecture:` snapshot, style preferences),
-   and `.memory-bank/techContext.md` plus `systemPatterns.md`.
+   and `.memory-bank/techContext.md` plus `systemPatterns.md` — noting the quality gates
+   `techContext.md` records (test, build, lint commands). A missing gate is a
+   `techContext.md` finding to report, never something to invent.
 2. **Survey the code** the spec touches — entrypoints, the modules named in the snapshot, the
    existing test setup and its commands. Plan against the repo as it is, not as it should be.
    If your tool supports subagents, delegate broad exploration and keep only the distilled
@@ -51,7 +58,9 @@ steps to real code.
    resolves a spec *Open point* is recorded in the spec (revise mode) before the plan is
    finalized — a plan must not silently outrun its spec.
 5. **Decompose into baby steps** (see below).
-6. **Write the plan file**, then hand it over for review and stop (see *Always* below).
+6. **Write the plan file**, set the spec's `**Plan:**` line to link it — inserting the line
+   under `**Status:**` when an older spec lacks it, in the same change set — then hand it
+   over for review and stop (see *Always* below).
 
 ## Research (do it, do not skip it)
 
@@ -61,6 +70,9 @@ behaviour · a protocol, standard or regulation · a pattern where your knowledg
 Web lookups are network access — the Ask-first gate in `AGENTS.md` applies: name the lookups
 and get one yes for the whole research batch.
 
+- If your tool supports subagents, delegate each lookup to an isolated agent and take back
+  only the distilled finding plus its source — raw pages crowd out planning judgement.
+  Without subagents, do the lookups inline; the recording duty below binds either way.
 - Check the version actually used in the repo (lock file, manifest) before trusting a doc page.
 - Prefer official documentation, release notes, and the project's own repository.
 - Record every source under `## Research`: title, link, one line on what it settled, and the
@@ -83,8 +95,13 @@ can be finished and checked on its own:
 - **Recorded**: the step's `Verified:` field stays empty until the `Verify:` line was actually
   run. A tick without a recorded result is a claim, not a verification.
 - **Red first**: when a step adds a test for a criterion, record its failing run in `Verified:`
-  before the implementation lands. A test that was never red decides nothing.
+  before the implementation lands. A test that was never red decides nothing. This binds new
+  behaviour only — a criterion preserving existing behaviour is decided by its existing test
+  staying green.
 - **Ordered so the repo keeps working** after every step; risky or blocking parts come first.
+- **Gated at the end**: the final step runs every quality gate the plan's `Quality gates:`
+  line names — a plan that ends without the full gate run is unfinished. Its `Covers:` line
+  names every criterion the gates re-prove.
 - **Tied to the spec**: each step names the acceptance criteria it serves, every criterion is
   covered by at least one step, and pure scaffolding steps say so explicitly.
 
@@ -111,8 +128,13 @@ this ever diverges, follow them and fix this file:
 
 ## Approach
 
-Two or three sentences: the strategy, why the steps are ordered this way, and which
-`.memory-bank/*` files the implementation will touch.
+Two or three sentences: the strategy, the chosen technologies or patterns with a one-line
+why each (long-lived decisions go dated to `systemPatterns.md` — link, don't duplicate),
+why the steps are ordered this way, and which `.memory-bank/*` files the implementation
+will touch.
+
+**Quality gates:** <the commands from `techContext.md` that Verify lines draw on; the
+final step runs them all>
 
 ## Research
 
@@ -174,6 +196,10 @@ Two or three sentences: the strategy, why the steps are ordered this way, and wh
    user at `/sdd-compile`.
 
 ## Mode C — the spec changed
+
+A pair sitting in `done/` means an `Implemented` spec is changing: report the impact first
+(steps 1–3), then propose the reactivation move — pair back to `active/`, spec and plan
+`In Progress` — via `/sdd-lifecycle`; a new slice of work gets a successor spec instead.
 
 1. Compare spec and plan: which acceptance criteria are new, changed, or gone?
 2. Read the traceability table **in reverse** — for every touched criterion, list the steps and

--- a/.claude/commands/sdd-specify.md
+++ b/.claude/commands/sdd-specify.md
@@ -213,7 +213,8 @@ spec has not been read yet. `AGENTS.md` and `.claude/rules/specs.md` stay author
 this ever diverges, follow them and fix this list:
 
 - Write the spec in `DocLanguage`.
-- Put `**Status:** Draft` directly under the H1.
+- Put `**Status:** Draft` directly under the H1, and `**Plan:** _none yet_` beneath it —
+  that line is maintained by `/sdd-plan`, never by hand.
 - Keep acceptance criteria explicit and **testable**.
 
 Then create the file (do not just print it): `.specs/backlog/NNNN-slug.md` — a new spec always
@@ -232,6 +233,7 @@ one-line reason: an absent negative space reads as permission.
 # <Title>
 
 **Status:** Draft
+**Plan:** _none yet_
 
 ## 1. Summary
 ## 2. Goal and problem

--- a/.claude/rules/plans.md
+++ b/.claude/rules/plans.md
@@ -21,7 +21,8 @@ cover only what is specific to **working inside a plan file**:
 - A test-adding step records its failing run first; the passing run lands with the
   implementation. A test that was never red decides nothing. Name the AC ID in the test's
   name or description, so the mapping survives outside the plan — and say in `Verified:`
-  *what* was red (failing assertion vs. missing module).
+  *what* was red (failing assertion vs. missing module). Red-first binds new behaviour only;
+  a preserved-behaviour criterion is decided by its existing test staying green.
 - **Update the file the moment a step's state changes**, in the same change set as the code:
   tick the checkbox, fill `Verified:` and `Notes`, move `Current step`, refresh `Last updated`,
   and rewrite `Session handoff` so a fresh session can continue from the file alone.

--- a/.claude/rules/specs.md
+++ b/.claude/rules/specs.md
@@ -19,6 +19,8 @@ is defined in `AGENTS.md` (loaded every session). These rules cover only what is
   actor. A criterion nothing can prove false is not a criterion.
 - State the spec's status on a `**Status:**` line near the top, using the vocabulary from
   `AGENTS.md`.
+- The `**Plan:**` line beneath it is maintained by `/sdd-plan` (`_none yet_` = unplanned);
+  never edit it by hand.
 
 Plan files (`.specs/**/*.plan.md`) have their own craft rules in `plans.md` — status
 vocabulary, step upkeep, and traceability live there, not here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ wins.
 
 ```yaml
 DocLanguage: English # set by /sdd-setup; governs project docs and dialogue; wiring stays English.
-FeatherSpecVersion: 1.2.0 # managed by /sdd-featherspec-update; do not edit by hand
+FeatherSpecVersion: 1.3.0 # managed by /sdd-featherspec-update; do not edit by hand
 ```
 
 ## Non-negotiables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ template-semver — **MAJOR** means derived projects need a real migration step,
 means additive capability that merges into a customized project, **PATCH** means wording and
 docs fixes that are safe to overwrite.
 
+## [1.3.0] - 2026-08-27
+
+### Added
+
+- `/sdd-plan` opens with a software-architect persona and, where the tool supports
+  subagents, delegates each research lookup to an isolated agent — only distilled,
+  source-backed findings enter the planning context.
+- Plans name their **quality gates**: the Approach block lists the test/build/lint commands
+  from `techContext.md`, step Verify lines draw on them, and the final step runs them all.
+- Bidirectional spec ↔ plan linkage: specs carry a `**Plan:**` line under their status,
+  maintained by `/sdd-plan`; plans already linked their spec.
+- `/sdd-lifecycle` gains the reactivation move: an `Implemented` spec whose behaviour
+  changes moves back to `active/` after `/sdd-plan` Mode C's impact report.
+
+### Changed
+
+- The plan's Approach block records chosen technologies with a one-line rationale each;
+  long-lived decisions go dated to `systemPatterns.md`.
+
 ## [1.2.0] - 2026-08-26
 
 ### Added
@@ -152,6 +171,7 @@ docs fixes that are safe to overwrite.
 - Rule duplication removed so the single-source promise holds.
 - `.gitignore` for local agent configuration.
 
+[1.3.0]: https://github.com/GregorBiswanger/featherspec/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/GregorBiswanger/featherspec/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/GregorBiswanger/featherspec/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/GregorBiswanger/featherspec/compare/v0.4.0...v1.0.0


### PR DESCRIPTION
Raises the quality of `/sdd-plan` per the analyzed gaps against SDD best practices (GitHub Spec Kit, AWS Kiro) — all additions token-lean (+72/−9 across eight files; `sdd-plan.md` grows by 26 lines, `AGENTS.md` untouched at 199/200 apart from the in-place version stamp).

## What changes

- **Architect persona** — `/sdd-plan` now opens with a four-line role framing: architect/tech lead, grounded in the repo as it is, "you decide the how; the spec owns the what".
- **Delegated research grounding** — where the tool supports subagents, each web lookup runs in an isolated agent; only the distilled, source-backed finding enters the planning context. Inline fallback unchanged; the link+date recording duty binds either way.
- **Named quality gates** — Mode A reads the test/build/lint commands from `techContext.md` (missing gates are a finding, never invented); the plan's Approach block carries a `**Quality gates:**` line; the final step always runs the full gates, with its `Covers:` semantics defined.
- **Bidirectional spec ↔ plan linkage** — specs now carry a `**Plan:**` line under their status, written by `/sdd-plan` (inserted into older specs on first planning); the plan already linked its spec. Maintained-by rule added to `.claude/rules/specs.md`.
- **Technology rationale** — the Approach block names chosen technologies/patterns with a one-line why each; long-lived decisions go dated to `systemPatterns.md`.
- **Reactivation path** — `/sdd-lifecycle` defines the `done/ → active/` move for an `Implemented` spec whose behaviour changes; `/sdd-plan` Mode C reports the impact first (traceability read in reverse), then proposes the move — successor specs stay the answer for new slices.
- **Red-first clarified** — binds new behaviour only; preserved-behaviour criteria are decided by their existing test staying green (closes a real two-readings gap found in rehearsal).

## Release contents (per the Releasing ritual)

`FeatherSpecVersion: 1.3.0` · ledger entry `### 1.3.0 — minor` with data-notes (older specs/plans get the new lines *offered* by `/sdd-featherspec-update`, never forced) and a version probe · `CHANGELOG.md` section with compare link. **On merge:** tag the merge commit `v1.3.0`, create the GitHub release from the CHANGELOG section, and push the staged wiki commit (Commands + Specs-and-Plans updates are committed locally in the wiki clone, held back until release).

## Verified

End-to-end rehearsal in a scratch project (Node 22, mini spec with three EARS criteria, spec deliberately lacking the `Plan:` line): the executing agent produced a plan with technology rationale, the `Quality gates:` line drawn verbatim from `techContext.md` (absent build/lint gates reported as absent), a final full-gate step, red-first test steps with AC IDs in test names, full traceability, inserted the backlink into the older spec, stopped without writing code, and named the riskiest step at hand-off — all nine checklist points confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
