### PR TITLE
feat(clean): /sdd-clean context cleanup with token report (v1.4.0)

### DIFF
--- a/.claude/commands/sdd-architecture-update.md
+++ b/.claude/commands/sdd-architecture-update.md
@@ -61,6 +61,8 @@ Only after confirmation:
   `AGENTS.md`).
 - Measure `AGENTS.md` against the cap in `.claude/rules/constitution.md`; if over, propose an
   eviction per its order.
+- When the Memory Bank files have visibly outgrown their purpose during this sync, recommend
+  `/sdd-clean` in the delta report — never clean up here as a side effect.
 
 ## When invoked from /sdd-architecture-scan
 

--- a/.claude/commands/sdd-clean.md
+++ b/.claude/commands/sdd-clean.md
@@ -1,0 +1,105 @@
+---
+description: Context cleanup — analyze FeatherSpec's persistent markdown, dedupe and compact safely, with a token report.
+argument-hint: "[focus file] (optional)"
+disable-model-invocation: true
+---
+
+<!-- Single source for the /sdd-clean workflow. Claude Code runs this file directly;
+     GitHub Copilot reaches it through the thin loader in
+     .github/prompts/sdd-clean.prompt.md. Deliberately no shell injection and no
+     argument-variable substitution: Copilot supports neither. -->
+
+# /sdd-clean — Context Cleanup
+
+Persistent markdown is a paid resource: every line it holds loads into future context
+windows. This workflow keeps it at *as little as possible, as much as necessary* — maximum
+useful information per token, judged by semantic usefulness, never by raw size alone. It is
+manually invokable at any time; other workflows may recommend it, but cleanup never happens
+as a silent side effect. The user may name one file after the command; then only that file
+is analyzed and compacted. All dialogue and reports in `DocLanguage`; compacted files keep
+the language they are written in.
+
+## Scope and write authority
+
+Analyze all FeatherSpec-managed markdown; write only where this command has authority:
+
+| Files | Authority |
+| --- | --- |
+| `.memory-bank/*.md` | analyze + compact here |
+| `.architecture/*.md` maps | analyze + compact here (≤ 40-line budget per `.claude/rules/architecture-map.md`) |
+| `architecture:` snapshot in `AGENTS.md` | analyze only; observed drift hands over to `/sdd-architecture-update` — its gate stays the snapshot's only write path |
+| `.specs/**` specs and plans | analyze, report findings only — their commands and rules own edits; `AC-` and `T-` IDs are never cleanup material |
+| Wiring (`.claude/`, `.github/`, `AGENTS.md` prose) | out of scope — template-owned |
+
+## Phase 1 — Analyze (read-only)
+
+Read each in-scope file against its declared purpose (`AGENTS.md` Memory Bank list,
+`.claude/rules/memory-bank.md` with its routing table, `.claude/rules/architecture-map.md`
+for maps) and ask, in this order:
+
+1. **Misplaced?** Content in the wrong file moves to its declared home per the routing
+   table — moving is not deleting.
+2. **Duplicate?** A fact stated in several files keeps exactly one canonical home; the
+   others link or drop it.
+3. **Stale?** Spot-check claims against the repository — named paths, technologies,
+   assumptions. Stale content is updated or removed; git history is the archive, the live
+   file represents the current useful state.
+4. **Rediscoverable?** Inventories an agent can derive from the code in seconds (file
+   lists, obvious signatures) go. Intent, boundaries, constraints, conventions and traps
+   stay — the Memory Bank holds knowledge, not a second copy of the repository.
+5. **Historical?** `activeContext.md` is the current working state, not a diary: finished
+   episodes leave; decisions that still matter move, dated, to `systemPatterns.md`.
+6. **Verbose?** Compact prose into facts without losing meaning. Reasoning stays when it
+   binds future decisions ("new persistence tech needs architecture approval"), goes when
+   it only narrates the past.
+7. **Over budget?** `activeContext.md` against its size limit in `AGENTS.md`; maps against
+   their 40 lines. Over budget triggers the checks above — never blind truncation.
+
+Estimate context cost as tokens ≈ bytes ÷ 4 and say it is an estimate — one command for the
+whole scope (e.g. `git ls-files '.memory-bank/*.md' '.architecture/*.md' | xargs wc -c`),
+no other tooling.
+
+**Never remove knowledge just to save tokens.** Always preserved: architectural decisions
+and constraints, business rules, security requirements, compatibility notes, non-obvious
+dependencies, project conventions, anything not reliably rediscoverable. Unsure whether
+something is safe to drop → keep it and list it for the user's review.
+
+## Phase 2 — Plan and gate
+
+Present the cleanup plan before touching anything:
+
+```text
+FeatherSpec Context Cleanup
+Files analyzed: 7 · already concise: 4
+~ compact: activeContext.md (finished episodes) · techContext.md (verbose prose)
+! duplicate: "modular monolith" in systemPatterns.md + techContext.md → canonical: systemPatterns.md
+? verify: techContext.md names Redis — not found in the repository
+Report-only: 0007-user-login.plan.md handoff looks finished (its own command edits it)
+Estimated: 5,900 → ~3,800 tokens (−36 %) · preserved: decisions, constraints, conventions
+Apply? (yes / details <file> / abort)
+```
+
+One yes covers the listed edits; every `?` line is applied only after its own answer, and
+that answer covers the fact everywhere it appears. Nothing outside the plan gets written.
+
+## Phase 3 — Apply
+
+Replace, merge, consolidate, shorten, move — never append a corrected version below an old
+one. Keep each file's structure as its rule defines it; refresh (or add) the `Last updated`
+line of every file you touch. Snapshot drift found in Phase 1: run
+`/sdd-architecture-update` exactly as if the user had typed it, with your findings as the
+observed state — do not edit the snapshot here. A never-initialized snapshot (`TBD` values)
+is a `/sdd-architecture-scan` recommendation, not drift.
+
+## Phase 4 — Validate and report
+
+Re-read every changed file: it still answers its purpose in 30 seconds, no preserved-list
+item was lost, no meaning inverted. Re-estimate sizes and report: files analyzed/changed,
+tokens before → after with the reduction, what was removed (duplicate · stale ·
+rediscoverable · historical), what was preserved, report-only findings, and a one-word
+context health. Then propose one commit (git writes stay behind the Ask-first gate in
+`AGENTS.md`).
+
+Re-running after a cleanup is free and safe: already-optimized files report "already
+concise" and nothing is written. Never re-compact content that already states one fact per
+line just to reword it — stability is part of the contract.

--- a/.claude/commands/sdd-featherspec-update.md
+++ b/.claude/commands/sdd-featherspec-update.md
@@ -436,3 +436,8 @@ entries compose sequentially across skipped versions.
   insert, linking an existing plan file) · plans gain a `**Quality gates:**` line in
   Approach (detect: plan without one · offer: per-file insert)
 - probes: `sdd-plan.md` without the architect persona ⇒ ≤1.2.0
+
+### 1.4.0 — minor (2026-08-27)
+- adds: `/sdd-clean` (body + loader) — context cleanup for the persistent markdown with a
+  token report · `/sdd-architecture-update` may recommend it on visible Memory Bank growth
+- probes: `sdd-clean.md` absent ⇒ ≤1.3.0

--- a/.github/prompts/sdd-clean.prompt.md
+++ b/.github/prompts/sdd-clean.prompt.md
@@ -1,0 +1,13 @@
+---
+name: sdd-clean
+description: Context cleanup — analyze FeatherSpec's persistent markdown, dedupe and compact safely, with a token report.
+argument-hint: "[focus file] (optional)"
+---
+
+# /sdd-clean
+
+Follow [`.claude/commands/sdd-clean.md`](../../.claude/commands/sdd-clean.md) exactly — read that file
+first and treat it as your instructions for this turn. It is the single source for this
+workflow; this file only points at it and holds no rules of its own.
+
+Anything the user typed after the command is the argument the workflow refers to.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ wins.
 
 ```yaml
 DocLanguage: English # set by /sdd-setup; governs project docs and dialogue; wiring stays English.
-FeatherSpecVersion: 1.3.0 # managed by /sdd-featherspec-update; do not edit by hand
+FeatherSpecVersion: 1.4.0 # managed by /sdd-featherspec-update; do not edit by hand
 ```
 
 ## Non-negotiables
@@ -79,8 +79,6 @@ load in every session; that is what makes them binding. This section is never fi
 - **Formatting**: Follow the project's formatter / linter configuration when present.
 
 ## Architecture & Design Snapshot (MUST SYNC)
-
-Agents orient by this snapshot — find modules and entrypoints here instead of scanning the tree.
 
 ### Rule: Run the architecture update unprompted
 
@@ -191,6 +189,7 @@ list — commands render it from here.
 | `/sdd-lifecycle` | Spec status and moves between backlog/active/done |
 | `/sdd-style-update` | Capture coding style preferences into `AGENTS.md` |
 | `/sdd-featherspec-update` | Template version check + safe update from a newer release (customizations preserved) |
+| `/sdd-clean` | Context cleanup: dedupe and compact the persistent markdown safely, with a token report |
 
 Flow — the only source of the recommended order; commands render it from here:
 `/sdd-specify` → `/sdd-clarify` → `/sdd-plan` → human reads the plan → `/sdd-lifecycle`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ template-semver — **MAJOR** means derived projects need a real migration step,
 means additive capability that merges into a customized project, **PATCH** means wording and
 docs fixes that are safe to overwrite.
 
+## [1.4.0] - 2026-08-27
+
+### Added
+
+- `/sdd-clean`: context cleanup for FeatherSpec's persistent markdown — analyzes every
+  managed file against its declared purpose, detects verbosity, duplicates, stale and
+  code-rediscoverable content, previews a cleanup plan behind one gate, compacts
+  semantically (decisions, constraints and conventions are always preserved), and reports
+  estimated tokens before → after. Snapshot drift hands over to
+  `/sdd-architecture-update`'s gate; specs and plans get report-only findings. Re-running
+  is safe: already-optimized files are left untouched.
+- `/sdd-architecture-update` recommends `/sdd-clean` when the Memory Bank has visibly
+  outgrown its purpose — cleanup itself never runs as a side effect.
+
 ## [1.3.0] - 2026-08-27
 
 ### Added
@@ -171,6 +185,7 @@ docs fixes that are safe to overwrite.
 - Rule duplication removed so the single-source promise holds.
 - `.gitignore` for local agent configuration.
 
+[1.4.0]: https://github.com/GregorBiswanger/featherspec/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/GregorBiswanger/featherspec/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/GregorBiswanger/featherspec/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/GregorBiswanger/featherspec/compare/v1.0.0...v1.1.0

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ criteria, then into a **plan** of baby steps — and only then writes code. Spec
 and progress all live on disk as Markdown in your repository, so the next session, the next
 teammate, and the next tool pick up exactly where you left off.
 
-Eleven `/sdd-*` commands drive that loop, and they behave identically in Claude Code and in
+Twelve `/sdd-*` commands drive that loop, and they behave identically in Claude Code and in
 GitHub Copilot, because both tools execute the **same files**.
 
 ---
@@ -301,7 +301,7 @@ runs faster because the context is already written down.
 
 ---
 
-## The eleven commands
+## The twelve commands
 
 | Command | What it does |
 | --- | --- |
@@ -316,6 +316,7 @@ runs faster because the context is already written down.
 | `/sdd-architecture-scan` | Deep, resumable scan of an existing codebase → architecture fingerprint |
 | `/sdd-style-update` | Capture a coding-style preference so it sticks |
 | `/sdd-featherspec-update` | Check your template version and update safely — customizations preserved |
+| `/sdd-clean` | Keep the persistent context lean: dedupe, drop stale content, compact — with a token report |
 
 New to it? Just run `/sdd-overview`.
 
@@ -328,7 +329,7 @@ AGENTS.md              the constitution — rules, doc language, template versio
 CLAUDE.md              one line: @AGENTS.md
 CHANGELOG.md           the template's release history (snapshot at adoption)
 
-.claude/commands/      the eleven workflow bodies (Claude runs them directly)
+.claude/commands/      the twelve workflow bodies (Claude runs them directly)
 .claude/rules/         path-scoped craft rules, loaded when a matching file is read
 .claude/settings.json  auto memory off, so the Memory Bank is the only project memory
 .github/prompts/       thin loaders so Copilot reaches the same bodies


### PR DESCRIPTION
Implements #6: `/sdd-clean` — a context-cleanup command that keeps FeatherSpec's persistent markdown at *as little as possible, as much as necessary*, with a token report. Token-lean by design: the body is 106 lines; `AGENTS.md` sits at 198/200 (one explanatory sentence evicted per the constitution's own eviction order to fund the new table row).

> **Stacked on #8** — merge #8 (v1.3.0) first; this PR then shows only its own delta and becomes v1.4.0. Both carry their release contents per the Releasing ritual.

## What the command does

- **Analyzes every managed file against its declared purpose** (`AGENTS.md` Memory Bank list, the memory-bank rule's routing table, the map rule's 40-line budget) with seven ordered checks: misplaced → duplicate → stale → code-rediscoverable → historical → verbose → over budget. Semantic usefulness decides, never raw size.
- **Write authority is scoped**: Memory Bank + `.architecture/` maps are compacted here; `architecture:` snapshot findings hand over to `/sdd-architecture-update`'s gate (one action, one autonomy level); specs/plans get report-only findings — `AC-`/`T-` IDs are never cleanup material; wiring is out of scope.
- **Previews before writing**: cleanup plan with a tokens ≈ bytes ÷ 4 estimate (stated as an estimate; one `wc -c` command, no tooling). One yes covers the listed edits; every uncertain `?` item is asked individually, and its answer covers that fact everywhere it appears.
- **Never removes knowledge to save tokens**: decisions, constraints, business rules, security requirements, conventions and non-obvious dependencies are always preserved; unsure means keep and list for review.
- **Applies by replacing/consolidating, never appending**; reports files analyzed/changed, tokens before → after with the reduction, removed categories, preserved list, and a context-health word; proposes one commit behind the Ask-first gate.
- **Re-running is safe**: already-optimized files report "already concise", nothing is written, and stable content is never reworded.
- `/sdd-architecture-update` may **recommend** `/sdd-clean` on visible Memory Bank growth — cleanup never happens as a side effect (issue's integration criterion).

## Documentation

README: command table + counts to twelve. Wiki (committed locally in the wiki clone, pushed with the v1.4.0 release): Commands section for `/sdd-clean`, a "Keeping it lean" section on the Memory Bank page, counts updated across Commands/Getting-Started/FAQ/Repository-Layout.

## Verified against the issue's acceptance criteria

End-to-end rehearsal on a scratch project with a deliberately bloated Memory Bank (finished episodes, duplicated "modular monolith" across three files, a Redis claim with no Redis in the repo, a service inventory copied from `src/`): the executing agent presented the plan with a ~731 → ~430 token estimate before any write, asked the two stale claims individually (Redis removed, PostgreSQL kept as *planned* per answer), canonicalized the duplicate to the dated `systemPatterns.md` decision, removed the rediscoverable inventory and the historical episodes, preserved both dated decisions byte-identically, rewrote files in place (never appended), reported −43 % with categories and a health word, committed behind the gate — and the immediate second run reported 4/4 "already concise" with **zero writes and no new commit**. All twelve verification points confirmed; three ambiguities the rehearsal surfaced were fixed in the body before this PR (uninitialized snapshot ≠ drift; "refresh or add" Last-updated; `?`-answer blast radius).

Closes #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
