### PR TITLE
FeatherSpec 1.6.0 — Verified Architecture Knowledge

### DIFF
--- a/.claude/commands/sdd-architecture-scan.md
+++ b/.claude/commands/sdd-architecture-scan.md
@@ -208,8 +208,12 @@ source-backed explanation kept as a `candidate` naming its source, and two disag
 sources kept as a `conflict` with neither chosen. A purely inferred explanation is dropped here
 and may reappear only as an option inside a clarification question. Persist a record only where
 the rule's bar is met — wiring, validation and logging never qualify. Records go into
-`.memory-bank/systemPatterns.md` under a `## Knowledge records` heading (in `DocLanguage`; the
-machine trigger is the `fs-knowledge:` block, never the heading text), created on first use.
+`.memory-bank/systemPatterns.md` under a `## Knowledge records` heading, created on first use
+together with the rule's four-line legend — a maintainer opening that file must understand what
+they are reading without a manual. Each record is a plain `###` heading stating the observation
+in `DocLanguage`, then its block; the heading is the statement and is never repeated inside.
+One shape only: what you can see in the code becomes a record whatever its reason state, and an
+intent with no code counterpart stays a dated *Key decisions* bullet with its provenance suffix.
 
 **Maps and the snapshot budget — deterministic, no judgment calls:** every **deep**
 unit gets a curated map `.architecture/<unit>.md` (≤ 40 lines each — this restates

--- a/.claude/commands/sdd-architecture-scan.md
+++ b/.claude/commands/sdd-architecture-scan.md
@@ -115,9 +115,12 @@ context; `.claude/rules/architecture-map.md` stays authoritative): write only
 five summary lines; the report schema — Purpose (2 sentences) · Entry points
 (exact paths) · Internal pattern (path patterns, e.g. "Application/<Feature>/ holds
 Command + Handler + Validator") · Dependencies in/out (concrete contract or event
-files) · Deviations from repo conventions · Traps and frozen zones · Observed,
-undocumented decisions (candidates for systemPatterns.md); and the leaf-report
-budget — the schema in ≤ 120 lines, where an honest report that cannot fit is the
+files) · Deviations from repo conventions · Traps and frozen zones · Observed
+decisions (the observation with its evidence path; any explanation found in a source —
+ADR, requirement, README, code comment — quoted with that source's path; the ADR,
+decision and requirement documents found, e.g. under `docs/adr/`, `docs/decisions/`,
+`adr/`, `*.adr.md`, `docs/requirements/`, `.specs/`; and never an inferred why); and
+the leaf-report budget — the schema in ≤ 120 lines, where an honest report that cannot fit is the
 split rule firing, never a reason to compress harder.
 
 <!-- Authority split, on purpose: procedural rules — the read ladder, the full-read
@@ -146,6 +149,10 @@ Full reads are budgeted: the delegation names the unit's tier and assigns the ca
 is the split rule firing — never silence, never compression. A shallow unit still
 reads heads, never names alone: minimum is the manifest plus the heads of the three
 to five most-referenced files.
+
+A pattern's purpose is an observation; its reason is not in the code. Record **where** an
+explanation is written — path, and line where it is a comment — never what it probably is,
+and never write a reason no source states. "This pattern is usually for X" is not a finding.
 
 Read and search only; run no commands and build nothing — the scan stays
 reproducible and side-effect-free, and command verification is Phase C's gated job.
@@ -180,14 +187,29 @@ synthesis finding to resolve here — not a scout error.
 Curation MUSTs for everything that survives: nothing an agent can infer from the code
 in seconds; path patterns over path lists; every documented command was executed once
 (commands that reach the network, such as package restores, fall under the ask-first
-rule in `AGENTS.md` — ask, or mark the command unverified); the *why* behind observed
-decisions goes, dated and source-linked, to `.memory-bank/systemPatterns.md`; stack,
+rule in `AGENTS.md` — ask, or mark the command unverified); observed decisions become
+knowledge records in `.memory-bank/systemPatterns.md` per the classification below — a why
+without a trusted source is never written as a why, in **no** artifact: not in a map, not in a
+snapshot purpose clause, not in `techContext.md`; stack,
 build, run and test facts go to `.memory-bank/techContext.md`. Everything curated —
 snapshot wording, module maps, Memory Bank entries — is written in `DocLanguage` from
 `AGENTS.md`, and that includes the snapshot's own values, not just prose around them.
 The snapshot obeys the same curation bar: every `entrypoints:`/`modules:` line carries
 its path plus a one-clause purpose or trap — never a bare path. A snapshot that a
 directory listing could have produced is not a fingerprint.
+
+**Classification — what the system does, and why it was meant to.** Read
+`.claude/rules/knowledge-records.md` now and apply it; it is the single source and this paragraph
+is a labelled restatement of its shape only. Build the classification **in context** from the
+scout reports — write no index, no list, no lookup file anywhere. For every decision-relevant
+pattern: one observation with at least one evidence path. Its rationale becomes `decided` only
+where a trusted source states it and passes that rule's trust test; otherwise `unknown`, with any
+source-backed explanation kept as a `candidate` naming its source, and two disagreeing trusted
+sources kept as a `conflict` with neither chosen. A purely inferred explanation is dropped here
+and may reappear only as an option inside a clarification question. Persist a record only where
+the rule's bar is met — wiring, validation and logging never qualify. Records go into
+`.memory-bank/systemPatterns.md` under a `## Knowledge records` heading (in `DocLanguage`; the
+machine trigger is the `fs-knowledge:` block, never the heading text), created on first use.
 
 **Maps and the snapshot budget — deterministic, no judgment calls:** every **deep**
 unit gets a curated map `.architecture/<unit>.md` (≤ 40 lines each — this restates
@@ -239,3 +261,15 @@ observed state; its confirmation gate remains the snapshot's only write gate. Af
 confirmed merge, set `last deep scan` in the snapshot comment via that same update,
 then ask once, rendered in `DocLanguage`: "Delete the raw analysis in `.sdd-scan/`?
 (recommended)".
+
+Carry the records into that update as part of your distilled findings. Inside its gate dialogue,
+after its questions are answered and before anything is written, make **one** offer — the only
+sanctioned sibling of the worklist gate this command has. Name the subjects and their ids in
+brackets, in plain words, for the persisted `unknown` rationales whose subjects touch security,
+compliance or data integrity, or a change someone is plausibly about to make: "N observed
+patterns have no confirmed reason — <subject> [id], … Clarify now, or later when a change touches
+them?" **Later** writes a `deferred:` marker on exactly the records you named, in the same
+confirmed merge, and asks nothing further. **Now** runs a bounded round over exactly those
+records: one question per message, in the shape `.claude/rules/knowledge-records.md` gives, each
+answerable or deferrable. Never ask "why does X exist?" — ask what the change in front of you
+must preserve.

--- a/.claude/commands/sdd-architecture-update.md
+++ b/.claude/commands/sdd-architecture-update.md
@@ -29,6 +29,9 @@ reconcile them.
 1. Read the tree and the current snapshot.
 2. Identify changes that matter architecturally: new/moved/removed top-level folders; new
    entrypoints, apps, services, packages, modules; changed boundaries or shared components.
+   Where `.memory-bank/systemPatterns.md` holds `fs-knowledge:` blocks, read
+   `.claude/rules/knowledge-records.md` now and treat those records as reconciliation targets
+   too: a moved or renamed path that a record's evidence names is drift like any other.
 3. Present a **delta report**: what changed (observed), why it matters (brief), and the
    proposed updates to the snapshot and Memory Bank docs.
 
@@ -54,7 +57,13 @@ Only after confirmation:
   `DocLanguage`, one YAML list item per entry.
 - When `.architecture/` exists, update the affected module map(s) and their
   `# last reconciled:` lines in the same change set.
-- Update `.memory-bank/systemPatterns.md` (patterns/decisions).
+- Update `.memory-bank/systemPatterns.md` (patterns, decisions and knowledge records). Retarget
+  every evidence path and id reference the change moved, in this same change set. Report as
+  findings — never fix silently — an id no record answers, a duplicate id, a provenance source
+  that no longer exists, and a record whose evidence paths have all disappeared. That last one is
+  the only case where you *propose* retiring a record: name it in the delta report and leave a
+  one-line retired-id comment only after the user confirms. Never delete a record and never turn
+  `decided` into `unknown` on your own — only the user retracts a confirmed reason.
 - Update `.memory-bank/techContext.md` when stack, build or test facts changed.
 - Update `.memory-bank/activeContext.md` (recent changes + next steps; size limit from
   `AGENTS.md`).
@@ -65,8 +74,8 @@ Only after confirmation:
 
 ## When invoked from /sdd-architecture-scan
 
-Treat the scan's distilled findings as the observed state; include its coverage figures and
-navigation self-test score in the delta report; on confirmation also set `last deep scan` in
+Treat the scan's distilled findings as the observed state — knowledge records included; include
+its coverage figures and navigation self-test score in the delta report; on confirmation also set `last deep scan` in
 the snapshot comment. The gate above stays the snapshot's only write gate. If the findings
 arrive without a recorded self-test score, do not open the gate — send the scan back to run
 its self-test first: an unverified fingerprint is not observed state. On confirmation the
@@ -75,5 +84,11 @@ distilled findings replace the snapshot's **values**, not just its structure: wo
 is never a reason to keep weaker values. Persist the self-test score in the snapshot's
 `coverage:` line, and write nothing outside this gate's sync list — the constitution's own
 wiring prose is not a reconciliation target.
+
+When the scan hands over persisted `unknown` rationales, it makes exactly one offer inside this
+gate dialogue — after the two questions above are answered and before anything is written. That
+offer is the only sanctioned sibling of this gate; its wording and its bounded round live in
+`.claude/commands/sdd-architecture-scan.md`. Declining writes the `deferred:` markers in this
+same confirmed merge.
 
 Everything must remain **DocLanguage-aware**.

--- a/.claude/commands/sdd-featherspec-update.md
+++ b/.claude/commands/sdd-featherspec-update.md
@@ -488,4 +488,7 @@ entries compose sequentially across skipped versions.
   chosen · `/sdd-plan` treats an `unknown` rationale as unknown instead of as an assumption ·
   `/sdd-architecture-scan` may add exactly one bundled, declinable clarification offer inside
   the existing `/sdd-architecture-update` gate dialogue
+- semantic-flips (cont.): `/sdd-setup` asks Step 0 (documentation language) on every first run —
+  the shipped `DocLanguage:` value is a template default and no longer marks a run as a re-run;
+  a re-run is a repository a previous setup already touched
 - probes: `knowledge-records.md` absent ⇒ ≤1.5.0

--- a/.claude/commands/sdd-featherspec-update.md
+++ b/.claude/commands/sdd-featherspec-update.md
@@ -475,3 +475,17 @@ entries compose sequentially across skipped versions.
   `**Plan:**` plus `## Plan history`)
 - probes: `.github/instructions/` present ⇒ ≥1.5.0 · `sdd-clean.md` present without
   `.specs/plan-archive/` ⇒ 1.4.0
+
+### 1.6.0 — minor (2026-08-29)
+- adds: `.claude/rules/knowledge-records.md` (+ its `.github/instructions/` loader) — the
+  record shape, the two rationale states and the trusted-source test, loaded on a read of
+  `.memory-bank/systemPatterns.md` · an optional `## Knowledge records` section in
+  `systemPatterns.md`, created on the first record (the seed is untouched, nothing migrates)
+- semantic-flips: an architectural *why* is persisted only with a traceable source — the
+  scan's curation rule "the why behind observed decisions goes, dated and source-linked, to
+  systemPatterns.md" becomes "a why without a trusted source is never written as a why, in no
+  artifact" · two trusted sources that disagree are both kept under `conflict` and neither is
+  chosen · `/sdd-plan` treats an `unknown` rationale as unknown instead of as an assumption ·
+  `/sdd-architecture-scan` may add exactly one bundled, declinable clarification offer inside
+  the existing `/sdd-architecture-update` gate dialogue
+- probes: `knowledge-records.md` absent ⇒ ≤1.5.0

--- a/.claude/commands/sdd-plan.md
+++ b/.claude/commands/sdd-plan.md
@@ -40,6 +40,11 @@ steps to real code.
    and `.memory-bank/techContext.md` plus `.memory-bank/systemPatterns.md` — noting the quality gates
    `techContext.md` records (test, build, lint commands). A missing gate is a
    `techContext.md` finding to report, never something to invent.
+   Where `systemPatterns.md` holds `fs-knowledge:` blocks, read them by state and leave them that
+   way: an observation is a fact about the code, a `decided` rationale with its provenance is a
+   constraint you may rely on, and an `unknown` one is **not** — a step that depends on it says so
+   in its own words and offers no substitute reason. Two disagreeing sources under `conflict` stay
+   two; picking one is the user's call, not a planning shortcut.
 2. **Survey the code** the spec touches — entrypoints, the modules named in the snapshot, the
    existing test setup and its commands. Plan against the repo as it is, not as it should be.
    If your tool supports subagents, delegate broad exploration and keep only the distilled

--- a/.claude/commands/sdd-setup.md
+++ b/.claude/commands/sdd-setup.md
@@ -22,10 +22,13 @@ Open under a `🪶 **FeatherSpec**` banner with at most two short **English** se
 warm one-line welcome to the template and that setup starts with one question — then
 immediately ask **Step 0** (the language question). Everything before the language is
 chosen stays English and minimal: no SDD explanation, no command table yet.
-A mixed-language opening is exactly what this ordering prevents. On a re-run — `AGENTS.md`
-already holds a `DocLanguage`, or it arrived as an argument — open in that language,
-confirm it in one line instead of re-asking Step 0, and compress the orientation to one
-sentence: a re-run tunes, it does not re-onboard.
+A mixed-language opening is exactly what this ordering prevents. **A re-run is a repository a
+previous setup already touched** — the Memory Bank carries real content instead of `TBD`
+placeholders, or the snapshot has been reconciled at least once — or a run where the language
+arrived as an argument. Only then open in that language, confirm it in one line instead of
+re-asking Step 0, and compress the orientation to one sentence: a re-run tunes, it does not
+re-onboard. The `DocLanguage:` value the template ships with is a default nobody chose, so it
+never makes a run a re-run: a first setup asks Step 0 even though `AGENTS.md` carries a value.
 
 **After** `DocLanguage` is set, give the whole orientation in `DocLanguage`:
 
@@ -62,6 +65,9 @@ Keep the orientation short, then continue the wizard with Step 1.
 ## Step 0 (MUST be the first question)
 
 Ask exactly: **"In which language should the project documentation Markdown files be written?"**
+Ask it on every first setup. `AGENTS.md` always carries a `DocLanguage` value — that is the
+template's default, not the user's answer, and skipping the question because a value is present
+is the one way this step can silently fail.
 
 - If the user does not answer, infer it from the conversation language.
 - After a language is chosen, set `DocLanguage` in `AGENTS.md` (the **only** place it lives).

--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -21,13 +21,18 @@ only when the snapshot cap would otherwise evict navigation facts. The snapshot 
 Raw per-unit reports from `/sdd-architecture-scan`'s Phase B follow the schema, in order:
 Purpose (2 sentences) · Entry points (exact paths) · Internal pattern (path patterns) ·
 Dependencies in/out (concrete contract or event files) · Deviations from repo
-conventions · Traps and frozen zones · Observed, undocumented decisions.
+conventions · Traps and frozen zones · Observed decisions — the observation with its evidence
+path, any explanation found in a source quoted with that source's path, and the ADR, decision or
+requirement documents seen; never an inferred why.
 
 - Budget: a leaf report fits the schema in **≤ 120 lines**. If an honest report cannot,
   that is the split rule firing — a structural note plus proposed child units, never
   harder compression.
 - Three nested budgets, three purposes: ≤ 5 return lines protect the orchestrator ·
   ≤ 120 report lines protect the synthesis · ≤ 40 map lines protect the end artifact.
+- A pattern's *purpose* is an observation; its *reason* is not in the code. Record where an
+  explanation is written, never what it probably is — `.claude/rules/knowledge-records.md` is
+  authoritative for what may later become a confirmed reason.
 
 > Note: path-scoped rules load when a matching file is **read**. A brand-new map has
 > not been read yet, so `/sdd-architecture-scan` restates the schema and these budgets

--- a/.claude/rules/knowledge-records.md
+++ b/.claude/rules/knowledge-records.md
@@ -20,9 +20,9 @@ The section opens with this legend, once, in `DocLanguage` — a reader must not
 > prove nothing. `conflict` = two trusted sources disagree, and neither was chosen.
 
 Each record is a **heading a human can read** plus one small block. The heading *is* the
-observation — never repeat it inside the block:
+observation — never repeat it inside the block. Written out, a record looks like this: an `###`
+heading stating what you saw, a blank line, then a fenced `yaml` block —
 
-```markdown
 ### Order events and the outbox row are written in one transaction
 
 ```yaml
@@ -35,7 +35,6 @@ fs-knowledge:
       - {statement: "Delivery survives a broker outage.", source: ".specs/done/0001-baseline.md"}
     # conflict: [{statement, source}, …]  · deferred: {at: <date>}
     # a decided reason instead: statement + provenance {type, source (adr/spec) or role+origin (human), confirmedAt}
-```
 ```
 
 Headings and statements are in `DocLanguage`; field names stay English, so the shape survives a

--- a/.claude/rules/knowledge-records.md
+++ b/.claude/rules/knowledge-records.md
@@ -47,7 +47,9 @@ record ever goes into a file that loads every session.
 **One shape, one place: visible in the code → record · not yet in the code → bullet.** Everything
 you can *see* becomes a record, whatever its reason state. An intent with no code counterpart yet
 stays a dated *Key decisions* bullet with a `provenance: human (<workflow>)` suffix. Never both,
-never a third form.
+never a third form. That suffix marks **something a person said about the architecture** — never a
+workflow's note about its own run. "We ran a scan today" is bookkeeping; it carries no provenance
+and belongs in `activeContext.md`.
 
 ## What may become `decided`
 

--- a/.claude/rules/knowledge-records.md
+++ b/.claude/rules/knowledge-records.md
@@ -1,0 +1,81 @@
+---
+paths:
+  - .memory-bank/systemPatterns.md
+---
+
+# Knowledge records — what the system does, and why it was meant to
+
+No `fs-knowledge:` block and no `provenance:` suffix in the file you are reading? Nothing below
+applies. **Evidence establishes what the system does; provenance establishes why it was meant
+that way; missing intent stays unknown until knowing it actually matters.**
+
+## The record
+
+```yaml
+fs-knowledge:
+  id: arch-outbox-001                       # stable, never reused, unique in the project
+  observation:
+    statement: "Order events are written to an outbox table inside the business transaction."
+    evidence:                               # ≥ 1 path (optionally :symbol), or "absent: <path> (<doc>)"
+      - src/infrastructure/outbox/OutboxDispatcher.ts
+  rationale:
+    state: unknown                          # decided | unknown — nothing else
+    candidates:                             # optional, while unknown: source-backed but untrusted
+      - {statement: "The feed refreshes once a minute.", source: "src/shared/cache/TtlCache.ts:7"}
+    # conflict:  [{statement, source}, …]   two trusted sources disagreeing — keep both, pick neither
+    # deferred:  {at: 2026-08-29}           the user postponed the question
+    # retracted: {statement, provenance, at}  a confirmation the user withdrew
+```
+
+A `decided` rationale replaces `state: unknown` with three lines:
+
+```yaml
+    state: decided
+    statement: "Finance must reconstruct an order's exact state at the time it was paid."
+    provenance: {type: adr, source: docs/adr/0001-event-sourcing.md, confirmedAt: 2026-03-14}
+```
+
+≤ 12 lines per record, one fenced block each, in `.memory-bank/systemPatterns.md` only. Other
+artifacts carry the **id** and never a copy. Never in a file that loads every session.
+
+## What may become `decided`
+
+Only three sources, and each names itself in `provenance`:
+
+1. **`human`** — the user confirmed this exact statement in a workflow. Also record
+   `origin: stated` (they formulated it) or `origin: suggested` (they picked an option you wrote),
+   and `role` where they name one. A role is metadata, never permission.
+2. **`adr`** · 3. **`spec`** — a decision document, with its path, that passes the trust test.
+
+**Trust test.** A document *you did not write* (ADR, requirement doc — outside `.specs/`,
+`.memory-bank/`, `.architecture/`, `.sdd-*/`) is trusted when it states the rationale in its own
+text, its status is live (`Superseded`, `Rejected`, `Deprecated` are not) and it does not declare
+itself generated. In a document *FeatherSpec wrote*, the **statement** is the unit, not the file:
+only one carrying an explicit human-provenance marker is trusted, whatever the file's status — an
+`Implemented` spec was accepted as a description of what to build, not sentence by sentence as a
+record of why.
+
+**Never `decided`:** inference, pattern recognition, naming, "this pattern is usually for…",
+best practice, a code comment, a README, your own earlier output. A source-backed explanation
+becomes a `candidate` with its source. An explanation with no source is not written down at all.
+
+## When to persist, and when to ask
+
+Persist a record only when a change to its subject would be decided differently depending on the
+answer — **and** the rationale is `decided` but not recoverable from the evidence files, or
+`unknown` in a way that could block a future decision, or contested by two trusted sources.
+Wiring, validation and logging never qualify.
+
+**Ask only** when the change in front of you touches the record's subject **and** the repository
+does not settle the constraint **and** two options differ in an observable property — behaviour,
+a guarantee, a contract, what data survives — **and** the unknown reason could decide between
+them. Plus one override: a change that may alter a **security, compliance or data-integrity**
+guarantee while the repository does not say which guarantee must hold. Category alone never asks.
+
+A question states: what you verified · what you could not · why it matters for *this* decision ·
+which decision or guarantee it affects — then offers options, always including one that answers
+nothing and defers. Never ask "why does X exist?". Blocking blocks the one decision, never the
+run: state the open decision in what you write and carry on with everything else.
+
+Deferred once = not asked again this run; a later ask names the earlier deferral. Only the user
+retracts a `decided`. Never repair or delete a record you cannot parse — report it.

--- a/.claude/rules/knowledge-records.md
+++ b/.claude/rules/knowledge-records.md
@@ -34,7 +34,7 @@ fs-knowledge:
     candidates:                 # optional: found somewhere, proves nothing
       - {statement: "Delivery survives a broker outage.", source: ".specs/done/0001-baseline.md"}
     # conflict: [{statement, source}, …]  · deferred: {at: <date>}
-    # a decided reason instead: statement + provenance {type, source|role, origin, confirmedAt}
+    # a decided reason instead: statement + provenance {type, source (adr/spec) or role+origin (human), confirmedAt}
 ```
 ```
 

--- a/.claude/rules/knowledge-records.md
+++ b/.claude/rules/knowledge-records.md
@@ -11,32 +11,43 @@ that way; missing intent stays unknown until knowing it actually matters.**
 
 ## The record
 
+Records live under one `## Knowledge records` heading in `.memory-bank/systemPatterns.md`.
+The section opens with this legend, once, in `DocLanguage` — a reader must not need a manual:
+
+> *Observation* = what the code does, with a path to check it. *Reason* = why it was built that
+> way. `decided` = a trusted source says so, and the source is named. `unknown` = nobody wrote it
+> down; a normal, permanent state, not a defect. `candidates` = explanations found somewhere that
+> prove nothing. `conflict` = two trusted sources disagree, and neither was chosen.
+
+Each record is a **heading a human can read** plus one small block. The heading *is* the
+observation — never repeat it inside the block:
+
+```markdown
+### Order events and the outbox row are written in one transaction
+
 ```yaml
 fs-knowledge:
-  id: arch-outbox-001                       # stable, never reused, unique in the project
-  observation:
-    statement: "Order events are written to an outbox table inside the business transaction."
-    evidence:                               # ≥ 1 path (optionally :symbol), or "absent: <path> (<doc>)"
-      - src/infrastructure/outbox/OutboxDispatcher.ts
+  id: arch-outbox-001
+  evidence: [src/modules/orders/OrderService.ts, src/infrastructure/outbox/OutboxDispatcher.ts]
   rationale:
-    state: unknown                          # decided | unknown — nothing else
-    candidates:                             # optional, while unknown: source-backed but untrusted
-      - {statement: "The feed refreshes once a minute.", source: "src/shared/cache/TtlCache.ts:7"}
-    # conflict:  [{statement, source}, …]   two trusted sources disagreeing — keep both, pick neither
-    # deferred:  {at: 2026-08-29}           the user postponed the question
-    # retracted: {statement, provenance, at}  a confirmation the user withdrew
+    state: unknown              # decided | unknown — nothing else
+    candidates:                 # optional: found somewhere, proves nothing
+      - {statement: "Delivery survives a broker outage.", source: ".specs/done/0001-baseline.md"}
+    # conflict: [{statement, source}, …]  · deferred: {at: <date>}
+    # a decided reason instead: statement + provenance {type, source|role, origin, confirmedAt}
+```
 ```
 
-A `decided` rationale replaces `state: unknown` with three lines:
+Headings and statements are in `DocLanguage`; field names stay English, so the shape survives a
+language change. `evidence` needs ≥ 1 path (optionally `path:symbol`), or
+`"absent: <path> (<document naming it>)"` where the observation *is* that documented material has
+no counterpart in code. ≤ 10 block lines. Other artifacts carry the **id**, never a copy, and no
+record ever goes into a file that loads every session.
 
-```yaml
-    state: decided
-    statement: "Finance must reconstruct an order's exact state at the time it was paid."
-    provenance: {type: adr, source: docs/adr/0001-event-sourcing.md, confirmedAt: 2026-03-14}
-```
-
-≤ 12 lines per record, one fenced block each, in `.memory-bank/systemPatterns.md` only. Other
-artifacts carry the **id** and never a copy. Never in a file that loads every session.
+**One shape, one place: visible in the code → record · not yet in the code → bullet.** Everything
+you can *see* becomes a record, whatever its reason state. An intent with no code counterpart yet
+stays a dated *Key decisions* bullet with a `provenance: human (<workflow>)` suffix. Never both,
+never a third form.
 
 ## What may become `decided`
 
@@ -73,9 +84,8 @@ them. Plus one override: a change that may alter a **security, compliance or dat
 guarantee while the repository does not say which guarantee must hold. Category alone never asks.
 
 A question states: what you verified · what you could not · why it matters for *this* decision ·
-which decision or guarantee it affects — then offers options, always including one that answers
-nothing and defers. Never ask "why does X exist?". Blocking blocks the one decision, never the
-run: state the open decision in what you write and carry on with everything else.
-
-Deferred once = not asked again this run; a later ask names the earlier deferral. Only the user
-retracts a `decided`. Never repair or delete a record you cannot parse — report it.
+which decision or guarantee it affects — then offers options, always one of which answers nothing
+and defers. Never ask "why does X exist?". Blocking blocks the one decision, never the run: write
+the open decision down and carry on. Deferred once = not asked again this run; a later ask names
+the earlier deferral. Only the user retracts a `decided`. Never repair or delete a record you
+cannot parse — report it.

--- a/.claude/rules/memory-bank.md
+++ b/.claude/rules/memory-bank.md
@@ -13,7 +13,9 @@ defined in `AGENTS.md` (loaded every session). These rules cover only what is sp
 - Keep entries concise, factual, and actionable.
 - If architecture changes, update `systemPatterns.md` and record "Changed Recently" in `activeContext.md`.
 - Date and link every decision entry in `systemPatterns.md` (spec, plan or commit) — an
-  undatable decision cannot be judged stale. Structure facts live only in the `architecture:`
+  undatable decision cannot be judged stale. A knowledge record (`fs-knowledge:`) is dated by its
+  provenance, so an `unknown` rationale carries no date and needs none; see
+  `.claude/rules/knowledge-records.md`, which is authoritative for records. Structure facts live only in the `architecture:`
   snapshot; this file holds the why.
 
 > Note: path-scoped rules load when a matching file is **read**. A brand-new Memory Bank file

--- a/.github/instructions/knowledge-records.instructions.md
+++ b/.github/instructions/knowledge-records.instructions.md
@@ -1,0 +1,8 @@
+---
+applyTo: ".memory-bank/systemPatterns.md"
+description: "FeatherSpec knowledge record rules — observation, rationale, provenance (thin loader)."
+---
+
+Follow [`.claude/rules/knowledge-records.md`](../../.claude/rules/knowledge-records.md) — read that
+file now and apply its rules to the matching files you are working on. It is the single source for
+these rules; this loader only points at it and holds none of its own.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ globs mirror the rules' `paths:` globs. On divergence this file wins.
 ## Repository Settings (managed by /sdd-setup and /sdd-featherspec-update)
 
 ```yaml
-DocLanguage: English # set by /sdd-setup; governs project docs and dialogue; wiring stays English.
+DocLanguage: English # template default until /sdd-setup asks; governs docs and dialogue, wiring stays English.
 FeatherSpecVersion: 1.6.0 # managed by /sdd-featherspec-update; do not edit by hand
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ globs mirror the rules' `paths:` globs. On divergence this file wins.
 
 ```yaml
 DocLanguage: English # set by /sdd-setup; governs project docs and dialogue; wiring stays English.
-FeatherSpecVersion: 1.5.0 # managed by /sdd-featherspec-update; do not edit by hand
+FeatherSpecVersion: 1.6.0 # managed by /sdd-featherspec-update; do not edit by hand
 ```
 
 ## Non-negotiables

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ architecture:
 SDD context persists between sessions under `.memory-bank/`:
 
 - `.memory-bank/projectbrief.md` — mission, users, success criteria
-- `.memory-bank/systemPatterns.md` — architecture decisions & patterns
+- `.memory-bank/systemPatterns.md` — architecture decisions, patterns & knowledge records
 - `.memory-bank/activeContext.md` — short session dashboard: focus, active spec, recent
   changes, decisions in flight, blockers, next steps (**max 1–2 screen pages, ~60 lines**)
 - `.memory-bank/techContext.md` — stack, constraints, build/run/test info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ docs fixes that are safe to overwrite.
   dialogue: the unknowns that touch security, compliance or data integrity, named with their
   ids, answerable now or deferred with one word. Declining is free and asks nothing further.
 
+### Fixed
+
+- **`/sdd-setup` asks for the documentation language again.** The template ships
+  `DocLanguage: English`, and the wizard treated "`AGENTS.md` already holds a `DocLanguage`" as
+  the mark of a re-run — a condition every fresh adoption satisfies. Step 0, which the command
+  declares MUST be its first question, was therefore skipped on first runs and new projects
+  silently got English. A re-run is now what it was always meant to be: a repository a previous
+  setup already touched — a seeded Memory Bank, or a reconciled snapshot.
+
 ### Changed
 
 - **The scan no longer writes an unsourced *why* anywhere** — not in a module map, not in a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,40 @@ template-semver — **MAJOR** means derived projects need a real migration step,
 means additive capability that merges into a customized project, **PATCH** means wording and
 docs fixes that are safe to overwrite.
 
+## [1.6.0] - 2026-08-29
+
+### Added
+
+- **Knowledge records**: `/sdd-architecture-scan` now separates what it can *see* from why it
+  was *meant* that way. An observation carries at least one evidence path; its rationale is
+  either `decided` — with provenance naming the ADR, the requirement document or the human
+  who confirmed it — or `unknown`. Records live as small YAML blocks in
+  `.memory-bank/systemPatterns.md`; every other artifact references them by id. No new
+  command, no second store, no migration: existing projects keep working untouched, and a
+  project without records never loads the rule.
+- **Conflicting sources stay conflicting**: when two trusted documents give incompatible
+  reasons for the same pattern, both are recorded under `conflict` and neither is chosen.
+  Silently adopting the one that reads best is how a false constraint becomes project truth.
+- **One bundled clarification offer** at the end of a scan, inside the existing confirmation
+  dialogue: the unknowns that touch security, compliance or data integrity, named with their
+  ids, answerable now or deferred with one word. Declining is free and asks nothing further.
+
+### Changed
+
+- **The scan no longer writes an unsourced *why* anywhere** — not in a module map, not in a
+  snapshot purpose clause, not in `techContext.md`. An explanation found in a code comment or
+  a README is kept as a `candidate` with its source; an explanation with no source is not
+  written down at all.
+- **Scouts report where an explanation is written, never what it probably means.** Their
+  report schema gains the source paths and the decision documents they found.
+- **`/sdd-plan` reads knowledge by state**: a `decided` rationale is a constraint it may rely
+  on, an `unknown` one is stated as unknown in the step that depends on it, and no assumed
+  reason is presented as an architectural constraint.
+- **`/sdd-architecture-update` maintains records through its existing gate**: evidence paths
+  and id references are retargeted in the same change set, orphaned references are reported
+  as findings, and a record whose code is gone is *proposed* for retirement — never removed,
+  and never downgraded, without confirmation.
+
 ## [1.5.0] - 2026-08-28
 
 ### Added
@@ -290,6 +324,7 @@ docs fixes that are safe to overwrite.
 - Rule duplication removed so the single-source promise holds.
 - `.gitignore` for local agent configuration.
 
+[1.6.0]: https://github.com/GregorBiswanger/featherspec/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/GregorBiswanger/featherspec/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/GregorBiswanger/featherspec/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/GregorBiswanger/featherspec/compare/v1.2.0...v1.3.0

--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ The payoff: agents jump straight to the right files instead of exploring — wit
 conventions and traps as grounds for better technical decisions — and the documentation can
 never flood the context window: always loaded is only the ~200-line constitution, while
 per-module depth lives in ≤ 40-line maps that load only when their module is touched.
+
+And it keeps *what it can see* apart from *why it was meant that way*. An observed pattern
+always carries an evidence path; its reason is recorded only when a source states it — an ADR,
+a requirement, or you — and stays **unknown** when none does, instead of being filled with a
+plausible guess that the next session inherits as fact. Where two documents give the assistant
+incompatible reasons for the same thing, it keeps both and picks neither. You are asked about
+an unknown reason once, bundled at the end of the scan, and "later" is a complete answer.
 The full walkthrough lives in the wiki:
 [Adopting an Existing Codebase](https://github.com/GregorBiswanger/featherspec/wiki/Adopting-an-Existing-Codebase).
 
@@ -347,7 +354,7 @@ CHANGELOG.md           the template's release history (snapshot at adoption)
 .vscode/settings.json  Copilot wiring: instructions/prompts locations, local memory tool off
 
 .specs/                backlog/ · active/ · done/ · plan-archive/ — specs, plans, frozen plan history (ships empty)
-.memory-bank/          projectbrief · systemPatterns · techContext · activeContext
+.memory-bank/          projectbrief · systemPatterns (decisions, patterns, knowledge records) · techContext · activeContext
 ```
 
 A deep scan may add one more: `.architecture/` — optional curated per-module maps, created


### PR DESCRIPTION
### Added

- **Knowledge records**: `/sdd-architecture-scan` now separates what it can *see* from why it
  was *meant* that way. An observation carries at least one evidence path; its rationale is
  either `decided` — with provenance naming the ADR, the requirement document or the human
  who confirmed it — or `unknown`. Records live as small YAML blocks in
  `.memory-bank/systemPatterns.md`; every other artifact references them by id. No new
  command, no second store, no migration: existing projects keep working untouched, and a
  project without records never loads the rule.
- **Conflicting sources stay conflicting**: when two trusted documents give incompatible
  reasons for the same pattern, both are recorded under `conflict` and neither is chosen.
  Silently adopting the one that reads best is how a false constraint becomes project truth.
- **One bundled clarification offer** at the end of a scan, inside the existing confirmation
  dialogue: the unknowns that touch security, compliance or data integrity, named with their
  ids, answerable now or deferred with one word. Declining is free and asks nothing further.

### Fixed

- **`/sdd-setup` asks for the documentation language again.** The template ships
  `DocLanguage: English`, and the wizard treated "`AGENTS.md` already holds a `DocLanguage`" as
  the mark of a re-run — a condition every fresh adoption satisfies. Step 0, which the command
  declares MUST be its first question, was therefore skipped on first runs and new projects
  silently got English. A re-run is now what it was always meant to be: a repository a previous
  setup already touched — a seeded Memory Bank, or a reconciled snapshot.

### Changed

- **The scan no longer writes an unsourced *why* anywhere** — not in a module map, not in a
  snapshot purpose clause, not in `techContext.md`. An explanation found in a code comment or
  a README is kept as a `candidate` with its source; an explanation with no source is not
  written down at all.
- **Scouts report where an explanation is written, never what it probably means.** Their
  report schema gains the source paths and the decision documents they found.
- **`/sdd-plan` reads knowledge by state**: a `decided` rationale is a constraint it may rely
  on, an `unknown` one is stated as unknown in the step that depends on it, and no assumed
  reason is presented as an architectural constraint.
- **`/sdd-architecture-update` maintains records through its existing gate**: evidence paths
  and id references are retargeted in the same change set, orphaned references are reported
  as findings, and a record whose code is gone is *proposed* for retirement — never removed,
  and never downgraded, without confirmation.

---

## Two things that are not in the changelog

**A pre-existing `/sdd-setup` bug, fixed here.** The wizard declares its documentation-language
question *"MUST be the first question"*, and treated `AGENTS.md` already holding a `DocLanguage`
as the mark of a re-run — a condition every fresh adoption satisfies, because the template ships
`DocLanguage: English`. Step 0 was therefore skipped on first runs and new projects silently got
English. Present since the first commit, unrelated to this feature, listed under *Fixed*.

**A latent bug left untouched.** `hash.sh` inside `sdd-featherspec-update.md` reads correctly on
disk (`root="$1"; list="$2"; out="$3"`), but Claude Code substitutes positional arguments into a
command body: invoke `/sdd-featherspec-update` with any argument and the listing arrives as
`root="the"; list="local"; out="template"`, hashing nothing. Present since 1.5.0. Not fixed in
this release — it is unrelated to the feature and the updater is the riskiest file in the
repository; it deserves its own change.

## Evidence

Measured against a seeded-trap brownfield fixture (45 files, 13 traps, recorded ground truth),
three runs per arm plus confirmation runs, in `featherspec-evals`:

| | v1.5.0 | 1.6.0 |
| --- | --- | --- |
| Invents a reason no source supports | no — 3/3 | no — 5/5 |
| Leaves a contradiction between two trusted sources open | **never** — 0/3 | **always** — 5/5 |
| Marks anything as unresolved | **never** — 0/3 | **always** — 5/5 |

Cost: +28 % tokens, +31 % wall time, one bundled declinable question per scan. Verified on Claude
Code and on GitHub Copilot with GPT-5.6, in English and in German. The consumption half is
measured too: given a spec that removes the outbox, `/sdd-plan` asks which guarantee must survive
— with a "decide nothing now" option — instead of assuming one, and blocks only the affected
acceptance criterion. Updater rehearsal green: customizations preserved, stamp moved, backup
branch created.

Full record: `research-protocol-issue-11.md`, attached to issue #11.
